### PR TITLE
Arn 539 get criminogenic needs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/AssessmentNeedsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/AssessmentNeedsController.kt
@@ -24,7 +24,7 @@ class AssessmentNeedsController(private val assessmentNeedsService: AssessmentNe
       ApiResponse(responseCode = "200", description = "OK")
     ]
   )
-  @PreAuthorize("hasAnyRole('ROLE_PROBATION', 'ROLE_CRS_PROVIDER')")
+  @PreAuthorize("hasAnyRole('ROLE_PROBATION')")
   fun getCriminogenicNeedsByCrn(
     @Parameter(description = "CRN", required = true, example = "D1974X")
     @PathVariable crn: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/AssessmentNeedsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/AssessmentNeedsController.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.assessrisksandneeds.api.controllers
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AssessmentNeedsDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.services.AssessmentNeedsService
+
+@RestController
+class AssessmentNeedsController(private val assessmentNeedsService: AssessmentNeedsService) {
+
+  @RequestMapping(path = ["/needs/crn/{crn}"], method = [RequestMethod.GET])
+  @Operation(description = "Gets criminogenic needs for crn")
+  @ApiResponses(
+    value = [
+      ApiResponse(responseCode = "403", description = "Unauthorized"),
+      ApiResponse(responseCode = "404", description = "CRN Not Found"),
+      ApiResponse(responseCode = "200", description = "OK")
+    ]
+  )
+  @PreAuthorize("hasAnyRole('ROLE_PROBATION', 'ROLE_CRS_PROVIDER')")
+  fun getCriminogenicNeedsByCrn(
+    @Parameter(description = "CRN", required = true, example = "D1974X")
+    @PathVariable crn: String,
+  ): AssessmentNeedsDto {
+    return assessmentNeedsService.getAssessmentNeeds(crn)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/AssessmentNeedsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/AssessmentNeedsDto.kt
@@ -1,0 +1,93 @@
+package uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+data class AssessmentNeedsDto(
+  @Schema(description = "Collection of assessment need sections which have been answered and identified as needs")
+  val identifiedNeeds: Collection<AssessmentNeedDto>,
+  @Schema(description = "Collection of assessment need sections which have been answered but are not identified as needs")
+  val notIdentifiedNeeds: Collection<AssessmentNeedDto>,
+  @Schema(description = "Collection of assessment need sections which have not been answered")
+  val unansweredNeeds: Collection<AssessmentNeedDto>,
+  @Schema(description = "The date and time that the assessment needs were completed")
+  val assessedOn: LocalDateTime
+) {
+  companion object {
+    fun from(
+      needs: Collection<AssessmentNeedDto>,
+      offenderNeedsDto: OffenderNeedsDto,
+    ): AssessmentNeedsDto {
+      val unansweredNeeds = mutableListOf<AssessmentNeedDto>()
+      val identifiedNeeds = mutableListOf<AssessmentNeedDto>()
+      val notIdentifiedNeeds = mutableListOf<AssessmentNeedDto>()
+
+      for (needDto in needs) {
+        when (needDto.identifiedAsNeed) {
+          null -> unansweredNeeds.add(needDto)
+          true -> identifiedNeeds.add(needDto)
+          false -> notIdentifiedNeeds.add(needDto)
+        }
+      }
+      return AssessmentNeedsDto(
+        identifiedNeeds = identifiedNeeds,
+        notIdentifiedNeeds = notIdentifiedNeeds,
+        unansweredNeeds = unansweredNeeds,
+        assessedOn = offenderNeedsDto.assessedOn
+      )
+    }
+  }
+}
+
+data class AssessmentNeedDto(
+  @Schema(description = "The section of the need in oasys", example = "DRUG_MISUSE")
+  val section: String? = null,
+  @Schema(description = "The name of the section need", example = "Drug misuse")
+  val name: String? = null,
+  @Schema(description = "Represents whether the weighted score of the section is over the threshold", example = "true")
+  val overThreshold: Boolean? = null,
+  @Schema(description = "Whether the section answers indicate a risk of harm", example = "false")
+  val riskOfHarm: Boolean? = null,
+  @Schema(description = "Whether the section answers indicate a risk of reoffending", example = "false")
+  val riskOfReoffending: Boolean? = null,
+  @Schema(description = "Whether the section has been flagged as a low scoring need", example = "true")
+  val flaggedAsNeed: Boolean? = null,
+  @Schema(description = "The calculated severity of the need", example = "true")
+  val severity: NeedSeverity? = null,
+  @Schema(description = "Whether the section questions indicate that this section is a need", example = "true")
+  val identifiedAsNeed: Boolean? = null,
+  @Schema(description = "The weighted score for the section", example = "4")
+  val needScore: Long? = null
+) {
+  companion object {
+
+    fun from(section: String, offenderNeedDto: OffenderNeedDto): AssessmentNeedDto {
+      with(offenderNeedDto) {
+        return AssessmentNeedDto(
+          section = section,
+          name = name,
+          overThreshold = overThreshold,
+          riskOfHarm = riskOfHarm,
+          riskOfReoffending = riskOfReoffending,
+          flaggedAsNeed = flaggedAsNeed,
+          severity = severity,
+          identifiedAsNeed = identifiedAsNeed,
+          needScore = needScore
+        )
+      }
+    }
+
+    fun from(section: String, sectionMap: Map<String, String>): AssessmentNeedDto {
+      return AssessmentNeedDto(
+        section = section,
+        name = sectionMap[section]
+      )
+    }
+  }
+}
+
+enum class NeedSeverity {
+  NO_NEED,
+  STANDARD,
+  SEVERE
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/OffenderNeedsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/OffenderNeedsDto.kt
@@ -1,0 +1,21 @@
+package uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model
+
+import java.time.LocalDateTime
+
+data class OffenderNeedsDto(
+  val needs: Collection<OffenderNeedDto>,
+  val assessedOn: LocalDateTime,
+  val historicStatus: String
+)
+
+data class OffenderNeedDto(
+  val section: String? = null,
+  val name: String? = null,
+  val overThreshold: Boolean? = null,
+  val riskOfHarm: Boolean? = null,
+  val riskOfReoffending: Boolean? = null,
+  val flaggedAsNeed: Boolean? = null,
+  val severity: NeedSeverity? = null,
+  val identifiedAsNeed: Boolean? = null,
+  val needScore: Long? = null
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/restclient/AssessmentApiRestClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/restclient/AssessmentApiRestClient.kt
@@ -7,10 +7,10 @@ import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderNeedsDto
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.CurrentOffence
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.DynamicScoringOffences
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderAndOffencesDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderNeedsDto
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.PredictorType
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.PreviousOffences
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.services.SectionHeader

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/AssessmentNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/AssessmentNeedsService.kt
@@ -10,15 +10,18 @@ import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderNeedsD
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.restclient.AssessmentApiRestClient
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.services.exceptions.EntityNotFoundException
 
+const val currentStatus = "CURRENT"
+
 @Service
 class AssessmentNeedsService(private val assessmentClient: AssessmentApiRestClient) {
   fun getAssessmentNeeds(crn: String): AssessmentNeedsDto {
     log.info("Get needs for CRN: $crn")
     val offenderNeeds = assessmentClient.getNeedsForCompletedLastYearAssessment(crn)
-    if (offenderNeeds?.historicStatus != "CURRENT") {
+
+    if (offenderNeeds?.historicStatus != currentStatus) {
       throw EntityNotFoundException("Current needs for CRN: $crn could not be found")
     }
-    if (offenderNeeds.needs.isNullOrEmpty()) {
+    if (offenderNeeds.needs.isEmpty()) {
       throw EntityNotFoundException("No needs found for CRN: $crn")
     }
     log.info("Retrieved ${offenderNeeds.needs.size} needs for CRN: $crn")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/AssessmentNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/AssessmentNeedsService.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.assessrisksandneeds.services
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AssessmentNeedDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AssessmentNeedsDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderNeedDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderNeedsDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.restclient.AssessmentApiRestClient
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.services.exceptions.EntityNotFoundException
+
+@Service
+class AssessmentNeedsService(private val assessmentClient: AssessmentApiRestClient) {
+  fun getAssessmentNeeds(crn: String): AssessmentNeedsDto {
+    log.info("Get needs for CRN: $crn")
+    val offenderNeeds = assessmentClient.getNeedsForCompletedLastYearAssessment(crn)
+    if (offenderNeeds?.historicStatus != "CURRENT") {
+      throw EntityNotFoundException("Current needs for CRN: $crn could not be found")
+    }
+    if (offenderNeeds.needs.isNullOrEmpty()) {
+      throw EntityNotFoundException("No needs found for CRN: $crn")
+    }
+    log.info("Retrieved ${offenderNeeds.needs.size} needs for CRN: $crn")
+    val allOffenderNeedsMap = mapAllNeeds(offenderNeeds)
+    val assessmentNeeds = toAssessmentNeedDtos(allOffenderNeedsMap)
+
+    return AssessmentNeedsDto.from(assessmentNeeds, offenderNeeds)
+  }
+
+  private fun toAssessmentNeedDtos(needMapping: Map<String, OffenderNeedDto?>): List<AssessmentNeedDto> {
+    return needMapping.map { (section, offenderNeed) ->
+      if (offenderNeed == null) {
+        AssessmentNeedDto.from(section, needNames)
+      } else {
+        AssessmentNeedDto.from(section, offenderNeed)
+      }
+    }
+  }
+
+  private fun mapAllNeeds(offenderNeeds: OffenderNeedsDto): Map<String, OffenderNeedDto?> {
+    return needNames.keys.associateWith { needName ->
+      offenderNeeds.needs.firstOrNull { need ->
+        need.section.equals(needName)
+      }
+    }
+  }
+
+  val needNames = mapOf(
+    "ACCOMMODATION" to "Accommodation",
+    "EDUCATION_TRAINING_AND_EMPLOYABILITY" to "Education training and employability",
+    "FINANCIAL_MANAGEMENT_AND_INCOME" to "Financial management and income",
+    "RELATIONSHIPS" to "Relationships",
+    "LIFESTYLE_AND_ASSOCIATES" to "Lifestyle and associates",
+    "DRUG_MISUSE" to "Drug misuse",
+    "ALCOHOL_MISUSE" to "Alcohol misuse",
+    "EMOTIONAL_WELL_BEING" to "Emotional well being",
+    "THINKING_AND_BEHAVIOUR" to "Thinking and behaviour",
+    "ATTITUDES" to "Attitudes"
+  )
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/AssessmentNeedsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/AssessmentNeedsControllerTest.kt
@@ -39,22 +39,6 @@ class AssessmentNeedsControllerTest : IntegrationTestBase() {
       .expectStatus().isNotFound
   }
 
-  @Test
-  fun `get criminogenic needs returns not found for crn with no needs`() {
-    webTestClient.get().uri("/needs/crn/NO_NEEDS")
-      .headers(setAuthorisation(roles = listOf("ROLE_CRS_PROVIDER")))
-      .exchange()
-      .expectStatus().isNotFound
-  }
-
-  @Test
-  fun `get criminogenic needs returns not found for crn with needs which are not current`() {
-    webTestClient.get().uri("/needs/crn/NOT_CURRENT")
-      .headers(setAuthorisation(roles = listOf("ROLE_CRS_PROVIDER")))
-      .exchange()
-      .expectStatus().isNotFound
-  }
-
   private fun unscoredNeeds() = listOf(
     AssessmentNeedDto(
       section = "THINKING_AND_BEHAVIOUR",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/AssessmentNeedsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/AssessmentNeedsControllerTest.kt
@@ -1,0 +1,160 @@
+package uk.gov.justice.digital.hmpps.assessrisksandneeds.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AssessmentNeedDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AssessmentNeedsDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.NeedSeverity
+import java.time.LocalDateTime
+
+@AutoConfigureWebTestClient
+@DisplayName("Criminogenic Needs Tests")
+class AssessmentNeedsControllerTest : IntegrationTestBase() {
+
+  private val crn = "X123456"
+
+  @Test
+  fun `get criminogenic needs by crn`() {
+    val needsDto = webTestClient.get().uri("/needs/crn/$crn")
+      .headers(setAuthorisation(roles = listOf("ROLE_CRS_PROVIDER")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<AssessmentNeedsDto>()
+      .returnResult().responseBody
+
+    assertThat(needsDto?.assessedOn).isEqualTo(LocalDateTime.of(2021, 6, 21, 15, 55, 4))
+    assertThat(needsDto?.identifiedNeeds).containsExactlyInAnyOrderElementsOf(identifiedNeeds())
+    assertThat(needsDto?.notIdentifiedNeeds).containsExactlyInAnyOrderElementsOf(scoredNotNeeds())
+    assertThat(needsDto?.unansweredNeeds).containsExactlyInAnyOrderElementsOf(unscoredNeeds())
+  }
+
+  @Test
+  fun `get criminogenic needs returns not found`() {
+    webTestClient.get().uri("/needs/crn/NOT_FOUND")
+      .headers(setAuthorisation(roles = listOf("ROLE_CRS_PROVIDER")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `get criminogenic needs returns not found for crn with no needs`() {
+    webTestClient.get().uri("/needs/crn/NO_NEEDS")
+      .headers(setAuthorisation(roles = listOf("ROLE_CRS_PROVIDER")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  @Test
+  fun `get criminogenic needs returns not found for crn with needs which are not current`() {
+    webTestClient.get().uri("/needs/crn/NOT_CURRENT")
+      .headers(setAuthorisation(roles = listOf("ROLE_CRS_PROVIDER")))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  private fun unscoredNeeds() = listOf(
+    AssessmentNeedDto(
+      section = "THINKING_AND_BEHAVIOUR",
+      name = "Thinking and behaviour"
+    ),
+    AssessmentNeedDto(
+      section = "ATTITUDES",
+      name = "Attitudes"
+    )
+  )
+
+  private fun scoredNotNeeds() = listOf(
+    AssessmentNeedDto(
+      section = "EMOTIONAL_WELL_BEING",
+      name = "Emotional Well-Being",
+      overThreshold = false,
+      riskOfHarm = false,
+      riskOfReoffending = false,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.NO_NEED,
+      identifiedAsNeed = false
+    ),
+    AssessmentNeedDto(
+      section = "FINANCIAL_MANAGEMENT_AND_INCOME",
+      name = "Financial Management and Income",
+      overThreshold = false,
+      riskOfHarm = false,
+      riskOfReoffending = false,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.NO_NEED,
+      identifiedAsNeed = false
+    )
+  )
+
+  private fun identifiedNeeds() = listOf(
+    AssessmentNeedDto(
+      section = "ACCOMMODATION",
+      name = "Accommodation",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    AssessmentNeedDto(
+      section = "EDUCATION_TRAINING_AND_EMPLOYABILITY",
+      name = "4 - Education, Training and Employability",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    AssessmentNeedDto(
+      section = "RELATIONSHIPS",
+      name = "Relationships",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    AssessmentNeedDto(
+      section = "LIFESTYLE_AND_ASSOCIATES",
+      name = "Lifestyle and Associates",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    AssessmentNeedDto(
+      section = "DRUG_MISUSE",
+      name = "Drug Misuse",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    AssessmentNeedDto(
+      section = "ALCOHOL_MISUSE",
+      name = "Alcohol Misuse",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    )
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/AssessmentNeedsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/AssessmentNeedsControllerTest.kt
@@ -19,7 +19,7 @@ class AssessmentNeedsControllerTest : IntegrationTestBase() {
   @Test
   fun `get criminogenic needs by crn`() {
     val needsDto = webTestClient.get().uri("/needs/crn/$crn")
-      .headers(setAuthorisation(roles = listOf("ROLE_CRS_PROVIDER")))
+      .headers(setAuthorisation(roles = listOf("ROLE_PROBATION")))
       .exchange()
       .expectStatus().isOk
       .expectBody<AssessmentNeedsDto>()
@@ -34,7 +34,7 @@ class AssessmentNeedsControllerTest : IntegrationTestBase() {
   @Test
   fun `get criminogenic needs returns not found`() {
     webTestClient.get().uri("/needs/crn/NOT_FOUND")
-      .headers(setAuthorisation(roles = listOf("ROLE_CRS_PROVIDER")))
+      .headers(setAuthorisation(roles = listOf("ROLE_PROBATION")))
       .exchange()
       .expectStatus().isNotFound
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/IntegrationTestBase.kt
@@ -33,6 +33,7 @@ abstract class IntegrationTestBase {
     fun startMocks() {
       assessmentApiMockServer.start()
       assessmentApiMockServer.stubGetRoshRisksByCrn()
+      assessmentApiMockServer.stubGetLatestNeedsByCrn()
       assessmentApiMockServer.stubGetRSRPredictorScoring()
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/AssessmentNeedsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/AssessmentNeedsServiceTest.kt
@@ -1,0 +1,482 @@
+package uk.gov.justice.digital.hmpps.assessrisksandneeds.services
+
+import io.mockk.every
+import io.mockk.junit5.MockKExtension
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AssessmentNeedDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.NeedSeverity
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderNeedDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderNeedsDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.restclient.AssessmentApiRestClient
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.services.exceptions.EntityNotFoundException
+import java.time.LocalDateTime
+
+@ExtendWith(MockKExtension::class)
+@DisplayName("Assessment Need Service Tests")
+class AssessmentNeedsServiceTest {
+  private val assessmentApiRestClient: AssessmentApiRestClient = mockk()
+  private val assessmentNeedsService = AssessmentNeedsService(assessmentApiRestClient)
+
+  @Test
+  fun `get assessment needs by crn returns identified needs`() {
+
+    val crn = "CRN123"
+    val date = LocalDateTime.now()
+
+    every {
+      assessmentApiRestClient.getNeedsForCompletedLastYearAssessment(crn)
+    } returns OffenderNeedsDto(
+      needs = allOffenderNeeds(),
+      historicStatus = "CURRENT",
+      assessedOn = date
+    )
+
+    val needs = assessmentNeedsService.getAssessmentNeeds(crn)
+    assertThat(needs.assessedOn).isEqualTo(date)
+    assertThat(needs.identifiedNeeds).hasSize(10)
+    assertThat(needs.notIdentifiedNeeds).hasSize(0)
+    assertThat(needs.unansweredNeeds).hasSize(0)
+  }
+
+  @Test
+  fun `get assessment needs by crn includes unanswered needs`() {
+
+    val crn = "CRN123"
+    val date = LocalDateTime.now()
+
+    every {
+      assessmentApiRestClient.getNeedsForCompletedLastYearAssessment(crn)
+    } returns OffenderNeedsDto(
+      needs = offenderNeedsWithUnanswered(),
+      historicStatus = "CURRENT",
+      assessedOn = date
+    )
+
+    val needs = assessmentNeedsService.getAssessmentNeeds(crn)
+    assertThat(needs.assessedOn).isEqualTo(date)
+    assertThat(needs.identifiedNeeds).hasSize(8)
+    assertThat(needs.notIdentifiedNeeds).hasSize(0)
+    assertThat(needs.unansweredNeeds).isEqualTo(unansweredNeeds())
+  }
+
+  @Test
+  fun `get assessment needs by crn includes not identified needs`() {
+
+    val crn = "CRN123"
+    val date = LocalDateTime.now()
+
+    every {
+      assessmentApiRestClient.getNeedsForCompletedLastYearAssessment(crn)
+    } returns
+      OffenderNeedsDto(
+        needs = offenderNeedsWithNotIdentified(),
+        historicStatus = "CURRENT",
+        assessedOn = date
+      )
+
+    val needs = assessmentNeedsService.getAssessmentNeeds(crn)
+    assertThat(needs.assessedOn).isEqualTo(date)
+    assertThat(needs.identifiedNeeds).hasSize(8)
+    assertThat(needs.notIdentifiedNeeds).isEqualTo(notIdentifiedNeeds())
+    assertThat(needs.unansweredNeeds).hasSize(0)
+  }
+
+  @Test
+  fun `get assessment needs by crn throws Exception when empty needs found`() {
+    val crn = "CRN123"
+    val date = LocalDateTime.now()
+
+    every {
+      assessmentApiRestClient.getNeedsForCompletedLastYearAssessment(crn)
+    } returns OffenderNeedsDto(
+      emptyList(),
+      date,
+      "CURRENT"
+    )
+
+    val exception = assertThrows<EntityNotFoundException> {
+      assessmentNeedsService.getAssessmentNeeds(crn)
+    }
+    assertEquals(
+      "No needs found for CRN: $crn",
+      exception.message
+    )
+  }
+
+  @Test
+  fun `get assessment needs by crn throws Exception when needs are not current`() {
+    val crn = "CRN123"
+    val date = LocalDateTime.now()
+
+    every {
+      assessmentApiRestClient.getNeedsForCompletedLastYearAssessment(crn)
+    } returns OffenderNeedsDto(
+      allOffenderNeeds(),
+      date,
+      "HISTORIC"
+    )
+
+    val exception = assertThrows<EntityNotFoundException> {
+      assessmentNeedsService.getAssessmentNeeds(crn)
+    }
+    assertEquals(
+      "Current needs for CRN: $crn could not be found",
+      exception.message
+    )
+  }
+
+  private fun unansweredNeeds() = listOf(
+    AssessmentNeedDto(
+      section = "THINKING_AND_BEHAVIOUR",
+      name = "Thinking and behaviour"
+    ),
+    AssessmentNeedDto(
+      section = "ATTITUDES",
+      name = "Attitudes"
+    )
+  )
+
+  private fun notIdentifiedNeeds() = listOf(
+    AssessmentNeedDto(
+      section = "THINKING_AND_BEHAVIOUR",
+      name = "Thinking and behaviour",
+      overThreshold = false,
+      riskOfHarm = false,
+      riskOfReoffending = false,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.NO_NEED,
+      identifiedAsNeed = false
+    ),
+    AssessmentNeedDto(
+      section = "ATTITUDES",
+      name = "Attitudes",
+      overThreshold = false,
+      riskOfHarm = false,
+      riskOfReoffending = false,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.NO_NEED,
+      identifiedAsNeed = false
+    )
+  )
+
+  private fun allOffenderNeeds() = listOf(
+    OffenderNeedDto(
+      section = "EMOTIONAL_WELL_BEING",
+      name = "Emotional Well-Being",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "FINANCIAL_MANAGEMENT_AND_INCOME",
+      name = "Financial Management and Income",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "ACCOMMODATION",
+      name = "Accommodation",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "EDUCATION_TRAINING_AND_EMPLOYABILITY",
+      name = "4 - Education, Training and Employability",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "RELATIONSHIPS",
+      name = "Relationships",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "LIFESTYLE_AND_ASSOCIATES",
+      name = "Lifestyle and Associates",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "DRUG_MISUSE",
+      name = "Drug Misuse",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "ALCOHOL_MISUSE",
+      name = "Alcohol Misuse",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "THINKING_AND_BEHAVIOUR",
+      name = "Thinking and behaviour",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "ATTITUDES",
+      name = "Attitudes",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    )
+  )
+
+  private fun offenderNeedsWithNotIdentified() = listOf(
+    OffenderNeedDto(
+      section = "EMOTIONAL_WELL_BEING",
+      name = "Emotional Well-Being",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "FINANCIAL_MANAGEMENT_AND_INCOME",
+      name = "Financial Management and Income",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "ACCOMMODATION",
+      name = "Accommodation",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "EDUCATION_TRAINING_AND_EMPLOYABILITY",
+      name = "4 - Education, Training and Employability",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "RELATIONSHIPS",
+      name = "Relationships",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "LIFESTYLE_AND_ASSOCIATES",
+      name = "Lifestyle and Associates",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "DRUG_MISUSE",
+      name = "Drug Misuse",
+      overThreshold = true,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "ALCOHOL_MISUSE",
+      name = "Alcohol Misuse",
+      overThreshold = true,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "THINKING_AND_BEHAVIOUR",
+      name = "Thinking and behaviour",
+      overThreshold = false,
+      riskOfHarm = false,
+      riskOfReoffending = false,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.NO_NEED,
+      identifiedAsNeed = false
+    ),
+    OffenderNeedDto(
+      section = "ATTITUDES",
+      name = "Attitudes",
+      overThreshold = false,
+      riskOfHarm = false,
+      riskOfReoffending = false,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.NO_NEED,
+      identifiedAsNeed = false
+    )
+  )
+
+  private fun offenderNeedsWithUnanswered() = listOf(
+    OffenderNeedDto(
+      section = "EMOTIONAL_WELL_BEING",
+      name = "Emotional Well-Being",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "FINANCIAL_MANAGEMENT_AND_INCOME",
+      name = "Financial Management and Income",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "ACCOMMODATION",
+      name = "Accommodation",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "EDUCATION_TRAINING_AND_EMPLOYABILITY",
+      name = "4 - Education, Training and Employability",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "RELATIONSHIPS",
+      name = "Relationships",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "LIFESTYLE_AND_ASSOCIATES",
+      name = "Lifestyle and Associates",
+      overThreshold = false,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "DRUG_MISUSE",
+      name = "Drug Misuse",
+      overThreshold = true,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    ),
+    OffenderNeedDto(
+      section = "ALCOHOL_MISUSE",
+      name = "Alcohol Misuse",
+      overThreshold = true,
+      riskOfHarm = true,
+      riskOfReoffending = true,
+      flaggedAsNeed = false,
+      severity = NeedSeverity.SEVERE,
+      identifiedAsNeed = true,
+      needScore = 2
+    )
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/testutils/AssessmentApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/testutils/AssessmentApiMockServer.kt
@@ -141,6 +141,62 @@ class AssessmentApiMockServer : WireMockServer(9004) {
     )
   }
 
+  fun stubGetLatestNeedsByCrn() {
+    stubFor(
+      WireMock.get(
+        WireMock.urlEqualTo(
+          "/assessments/crn/$crn/needs/latest?period=YEAR&periodUnits=1"
+        )
+      )
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(needsJson)
+        )
+    )
+    stubFor(
+      WireMock.get(
+        WireMock.urlEqualTo(
+          "/assessments/crn/NOT_FOUND/needs/latest?period=YEAR&periodUnits=1"
+        )
+      )
+        .willReturn(
+          WireMock.aResponse()
+            .withBody(crnNotFoundJson)
+            .withStatus(404)
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+        )
+    )
+
+    stubFor(
+      WireMock.get(
+        WireMock.urlEqualTo(
+          "/assessments/crn/NOT_CURRENT/needs/latest?period=YEAR&periodUnits=1"
+        )
+      )
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(notCurrentNeedsJson)
+            .withStatus(404)
+        )
+    )
+
+    stubFor(
+      WireMock.get(
+        WireMock.urlEqualTo(
+          "/assessments/crn/NO_NEEDS/needs/latest?period=YEAR&periodUnits=1"
+        )
+      )
+        .willReturn(
+          WireMock.aResponse()
+            .withBody(emptyNeedsJson)
+            .withStatus(404)
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+        )
+    )
+  }
+
   companion object {
     val crnNotFoundJson =
       """{ "status": 404 , "developerMessage": "Latest COMPLETE with types [LAYER_1, LAYER_3] type not found for crn, RANDOMCRN" }""".trimIndent()
@@ -453,4 +509,135 @@ class AssessmentApiMockServer : WireMockServer(9004) {
 }
       """.trimIndent()
   }
+
+  private val needsJson = """
+    {
+    "needs": [
+      {
+          "section": "ACCOMMODATION",
+          "name": "Accommodation",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+      },
+      {
+          "section": "EDUCATION_TRAINING_AND_EMPLOYABILITY",
+          "name": "4 - Education, Training and Employability",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+      },
+      {
+          "section": "FINANCIAL_MANAGEMENT_AND_INCOME",
+          "name": "Financial Management and Income",
+          "overThreshold": false,
+          "riskOfHarm": false,
+          "riskOfReoffending": false,
+          "flaggedAsNeed": false,
+          "severity": "NO_NEED",
+          "identifiedAsNeed": false
+      },
+      {
+          "section": "RELATIONSHIPS",
+          "name": "Relationships",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+      },
+      {
+          "section": "LIFESTYLE_AND_ASSOCIATES",
+          "name": "Lifestyle and Associates",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+      },
+      {
+          "section": "DRUG_MISUSE",
+          "name": "Drug Misuse",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+      },
+      {
+          "section": "ALCOHOL_MISUSE",
+          "name": "Alcohol Misuse",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+      },
+      {
+          "section": "EMOTIONAL_WELL_BEING",
+          "name": "Emotional Well-Being",
+          "overThreshold": false,
+          "riskOfHarm": false,
+          "riskOfReoffending": false,
+          "flaggedAsNeed": false,
+          "severity": "NO_NEED",
+          "identifiedAsNeed": false
+      }
+    ],
+    "assessedOn": "2021-06-21T15:55:04",
+    "historicStatus": "CURRENT"
+  } """
+
+  private val notCurrentNeedsJson = """
+    {
+    "needs": [
+      {
+          "section": "ACCOMMODATION",
+          "name": "Accommodation",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+      },
+      {
+          "section": "EMOTIONAL_WELL_BEING",
+          "name": "Emotional Well-Being",
+          "overThreshold": false,
+          "riskOfHarm": false,
+          "riskOfReoffending": false,
+          "flaggedAsNeed": false,
+          "severity": "NO_NEED",
+          "identifiedAsNeed": false,
+          "needScore" : 0
+      }
+    ],
+    "assessedOn": "2021-06-21T15:55:04",
+    "historicStatus": "HISTORIC"
+  } """
+
+  private val emptyNeedsJson = """
+      {
+      "needs": [],
+      "assessedOn": "2021-06-21T15:55:04",
+      "historicStatus": "CURRENT"
+    } """
 }

--- a/wiremock/mappings/GetLatestCompletedAssessmentNeeds.json
+++ b/wiremock/mappings/GetLatestCompletedAssessmentNeeds.json
@@ -1,0 +1,106 @@
+{
+  "id": "3e862519-78b0-4449-b2b5-535ee1b81213",
+  "request": {
+    "method": "GET",
+    "urlPathPattern": "/assessments/crn/X123456/needs/latest?period=YEAR&periodUnits=1"
+  },
+  "response": {
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "status": 200,
+    "jsonBody":
+    {
+      "needs": [
+        {
+          "section": "ACCOMMODATION",
+          "name": "Accommodation",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "EDUCATION_TRAINING_AND_EMPLOYABILITY",
+          "name": "4 - Education, Training and Employability",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "FINANCIAL_MANAGEMENT_AND_INCOME",
+          "name": "Financial Management and Income",
+          "overThreshold": false,
+          "riskOfHarm": false,
+          "riskOfReoffending": false,
+          "flaggedAsNeed": false,
+          "severity": "NO_NEED",
+          "identifiedAsNeed": false
+        },
+        {
+          "section": "RELATIONSHIPS",
+          "name": "Relationships",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "LIFESTYLE_AND_ASSOCIATES",
+          "name": "Lifestyle and Associates",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "DRUG_MISUSE",
+          "name": "Drug Misuse",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "ALCOHOL_MISUSE",
+          "name": "Alcohol Misuse",
+          "overThreshold": false,
+          "riskOfHarm": true,
+          "riskOfReoffending": true,
+          "flaggedAsNeed": false,
+          "severity": "SEVERE",
+          "identifiedAsNeed": true,
+          "needScore" : 2
+        },
+        {
+          "section": "EMOTIONAL_WELL_BEING",
+          "name": "Emotional Well-Being",
+          "overThreshold": false,
+          "riskOfHarm": false,
+          "riskOfReoffending": false,
+          "flaggedAsNeed": false,
+          "severity": "NO_NEED",
+          "identifiedAsNeed": false
+        }
+      ],
+      "assessedOn": "2021-06-21T15:55:04",
+      "historicStatus": "CURRENT"
+    }
+  }
+}


### PR DESCRIPTION
This PR adds a new endpoint, `/needs/crn/{crn}`, to get the current assessed needs from an offender's CRN. The service calls the Offender Assessments Service endpoint to get the available needs and then returns all of the needs as either 

- those which have been calculated and identified as needs in the offender service, 
- those which have been calculated but are not identified as needs,
- those which were not returned from the offender service and so are not identified as needs