### PR TITLE
Arn 542

### DIFF
--- a/src/main/resources/db/migration/V1_1__predictor_scores.sql
+++ b/src/main/resources/db/migration/V1_1__predictor_scores.sql
@@ -1,0 +1,18 @@
+CREATE TABLE IF NOT EXISTS offender_predictor
+(
+    offender_predictor_id           serial          primary key,
+    offender_predictor_uuid         uuid            not null unique,
+    predictor_type                  varchar(100)    not null,
+    algorithm_version               varchar(10)     not null,
+    predictor_score                 varchar(10)     not null,
+    crn                             varchar(20)     not null,
+    predictor_trigger_source        varchar(200)    not null,
+    source_id                       varchar(200)    not null,
+    source_answers                  JSONB,
+    created_by                      text            not null,
+    created_date                    timestamp       not null,
+    CONSTRAINT unique_source UNIQUE(risk_source, source_id)
+);
+
+CREATE INDEX idx_crn ON offender_predictor(crn);
+CREATE INDEX idx_uuid ON offender_predictor(offender_predictor_uuid);

--- a/src/main/resources/db/migration/V1_1__predictor_scores.sql
+++ b/src/main/resources/db/migration/V1_1__predictor_scores.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS offender_predictors_history
     source_answers                  JSONB,
     created_by                      text            not null,
     created_date                    timestamp       not null,
-    CONSTRAINT unique_source UNIQUE(predictor_trigger_source, source_id)
+    CONSTRAINT predictors_history_unique_source UNIQUE(predictor_trigger_source, source_id)
 );
 
 CREATE INDEX idx_crn ON offender_predictors_history (crn);

--- a/src/main/resources/db/migration/V1_1__predictor_scores.sql
+++ b/src/main/resources/db/migration/V1_1__predictor_scores.sql
@@ -1,10 +1,10 @@
-CREATE TABLE IF NOT EXISTS offender_predictor
+CREATE TABLE IF NOT EXISTS offender_predictors_history
 (
     offender_predictor_id           serial          primary key,
-    offender_predictor_uuid         uuid            not null unique,
+    offender_predictor_uuid         UUID            not null unique,
     predictor_type                  varchar(100)    not null,
     algorithm_version               varchar(10)     not null,
-    predictor_score                 varchar(10)     not null,
+    calculated_at                   timestamp       not null,
     crn                             varchar(20)     not null,
     predictor_trigger_source        varchar(200)    not null,
     source_id                       varchar(200)    not null,
@@ -14,5 +14,17 @@ CREATE TABLE IF NOT EXISTS offender_predictor
     CONSTRAINT unique_source UNIQUE(risk_source, source_id)
 );
 
-CREATE INDEX idx_crn ON offender_predictor(crn);
-CREATE INDEX idx_uuid ON offender_predictor(offender_predictor_uuid);
+CREATE INDEX idx_crn ON offender_predictors_history (crn);
+CREATE INDEX idx_uuid ON offender_predictors_history (offender_predictor_uuid);
+
+CREATE TABLE IF NOT EXISTS predictors
+(
+    predictor_id                  serial  primary key,
+    predictor_uuid                UUID    not null unique,
+    offender_predictor_uuid       UUID        NOT NULL,
+    predictor_subtype             varchar(100)    not null,
+    predictor_score               varchar(10)     not null,
+    predictor_level               varchar(10)     not null,
+    created_date                  timestamp       not null,
+    FOREIGN KEY (offender_predictor_uuid) REFERENCES offender_predictors_history (offender_predictor_uuid)
+);

--- a/src/main/resources/db/migration/V1_1__predictor_scores.sql
+++ b/src/main/resources/db/migration/V1_1__predictor_scores.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS offender_predictors_history
     source_answers                  JSONB,
     created_by                      text            not null,
     created_date                    timestamp       not null,
-    CONSTRAINT unique_source UNIQUE(risk_source, source_id)
+    CONSTRAINT unique_source UNIQUE(predictor_trigger_source, source_id)
 );
 
 CREATE INDEX idx_crn ON offender_predictors_history (crn);

--- a/src/main/resources/db/migration/V1_1__predictor_scores.sql
+++ b/src/main/resources/db/migration/V1_1__predictor_scores.sql
@@ -14,8 +14,8 @@ CREATE TABLE IF NOT EXISTS offender_predictors_history
     CONSTRAINT predictors_history_unique_source UNIQUE(predictor_trigger_source, source_id)
 );
 
-CREATE INDEX idx_crn ON offender_predictors_history (crn);
-CREATE INDEX idx_uuid ON offender_predictors_history (offender_predictor_uuid);
+CREATE INDEX idx_offender_predictors_history_crn ON offender_predictors_history (crn);
+CREATE INDEX idx_offender_predictors_history_uuid ON offender_predictors_history (offender_predictor_uuid);
 
 CREATE TABLE IF NOT EXISTS predictors
 (


### PR DESCRIPTION
table for offender predictors history and the sub types associated to each predictor in case there are more like for example RSR - RSR,OSPC,OSPI.
```

offender_predictors_history
(1, '5966f545-8236-4375-87df-101201c5a30e', 'RSR', 3, '2021-08-09 14:46:48', 'CRN123', 'ASSESSMENTS_API', 'episodeuuid'
'{"code_a": {"answers": [{"items": []}]}, "code_bf": {"answers": [{"items": ["Additional information"]}]}',
 'AALONSO',
'2021-08-09 14:46:48'
);
```
```
predictors
(
1,
   'ebc215ff-6f3d-4e6d-9f82-c7ec4c2ebec4',
    '5966f545-8236-4375-87df-101201c5a30e',
     'RSR',
     48.78,
    'MEDIUM',
    '2021-08-09 14:46:48'
)
(
2,
   'fbc215ff-6f3d-4e6d-9f82-c7ec4c2ebec4',
    '5966f545-8236-4375-87df-101201c5a30e',
     'OSPC',
     40.78,
    'MEDIUM',
    '2021-08-09 14:46:48'
)
(
3,
   'ffc215ff-6f3d-4e6d-9f82-c7ec4c2ebec4',
    '5966f545-8236-4375-87df-101201c5a30e',
     'OSPI',
     30.78,
    'LOW',
    '2021-08-09 14:46:48'
)
```