### PR TITLE
return number of errors

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/RiskPredictorsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/RiskPredictorsDto.kt
@@ -11,7 +11,8 @@ data class RiskPredictorsDto(
   val type: PredictorType,
   val scoreType: ScoreType?,
   val scores: Map<PredictorSubType, Score>,
-  val errors: List<String> = emptyList()
+  val errors: List<String> = emptyList(),
+  val errorCount: Int
 )
 
 data class Score(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskPredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskPredictorService.kt
@@ -86,7 +86,8 @@ class RiskPredictorService(
               isValid = this.validOspiScore.toBoolean()
             ),
           ),
-          errors = this.toErrors()
+          errors = this.toErrors(),
+          errorCount = this.errorCount
         )
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
@@ -92,9 +92,9 @@ class RiskPredictorsControllerTest() : IntegrationTestBase() {
         Assertions.assertThat(it.responseBody).isEqualTo(
           RiskPredictorsDto(
             algorithmVersion = "3",
+            calculatedAt = LocalDateTime.of(2021, 7, 30, 16, 10, 2),
             type = PredictorType.RSR,
             scoreType = ScoreType.STATIC,
-            calculatedAt = LocalDateTime.of(2021, 7, 30, 16, 10, 2),
             scores = mapOf(
               PredictorSubType.RSR to Score(
                 level = ScoreLevel.HIGH, score = BigDecimal("11.34"), isValid = true
@@ -105,7 +105,8 @@ class RiskPredictorsControllerTest() : IntegrationTestBase() {
               PredictorSubType.OSPI to Score(
                 level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false
               ),
-            )
+            ),
+            errorCount= 0
           )
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
@@ -106,7 +106,7 @@ class RiskPredictorsControllerTest() : IntegrationTestBase() {
                 level = ScoreLevel.NOT_APPLICABLE, score = BigDecimal("0"), isValid = false
               ),
             ),
-            errorCount= 0
+            errorCount = 0
           )
         )
       }


### PR DESCRIPTION
Small change to return the errorCount in the Predictors calculator as the change has been requested by Capita