### PR TITLE
Add ONNX predictor service - initial spike

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   implementation("org.postgresql:postgresql")
   implementation("com.vladmihalcea:hibernate-types-52:2.12.1")
   implementation("com.beust:klaxon:5.5")
+  implementation("com.microsoft.onnxruntime:onnxruntime:1.9.0")
   runtimeOnly("com.h2database:h2:1.4.200")
   runtimeOnly("org.flywaydb:flyway-core:7.15.0")
   testRuntimeOnly("com.h2database:h2:1.4.200")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/OffenderAndOffencesDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/OffenderAndOffencesDto.kt
@@ -198,7 +198,10 @@ enum class EmploymentType(val score: Int? = null) {
 }
 
 enum class Gender(val value: String) {
-  MALE("M"), FEMALE("F")
+  MALE("M"), FEMALE("F");
+  fun toOnnxFormat(): String {
+    return if (this == MALE) "MALE" else "FEMALE"
+  }
 }
 
 enum class ProblemsLevel(val score: Int? = null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/OnnxPredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/OnnxPredictorService.kt
@@ -1,0 +1,236 @@
+package uk.gov.justice.digital.hmpps.assessrisksandneeds.services
+
+import ai.onnxruntime.OnnxTensor
+import ai.onnxruntime.OrtEnvironment
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderAndOffencesDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.PredictorSubType
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.PredictorType
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.RiskPredictorsDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.Score
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.ScoreType
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.services.exceptions.ONNXResponseFailure
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.Period
+import java.time.format.DateTimeFormatter
+
+@Service
+class OnnxPredictorService(@Value("\${onnx-predictors.onnx-path}") private val onnxFilePath: String) {
+
+  fun calculatePredictorScores(
+    offenderAndOffences: OffenderAndOffencesDto,
+  ): RiskPredictorsDto {
+
+    log.info("Generating RSR score using ONNX runtime for CRN ${offenderAndOffences.crn}")
+    val results = OrtEnvironment.getEnvironment().use { env ->
+      env.createSession(onnxFilePath).use { session ->
+
+        log.info("Loaded ONNX Runtime file from $onnxFilePath with ${session.numInputs} inputs and ${session.numOutputs}")
+
+        val aggregatedMap = buildStaticTensors(offenderAndOffences, env) +
+          buildDynamicTensors(offenderAndOffences, env) +
+          buildPreviousOffencesTensors(offenderAndOffences, env) +
+          buildCurrentOffencesTensors(offenderAndOffences, env)
+
+        // Identify if any ONNX input parameters are missing and log an error
+        val missingTensors = session.inputNames.asSequence().minus(aggregatedMap.keys).toList()
+        if (missingTensors.isNotEmpty()) log.error("ONNX parameters not provided: $missingTensors")
+
+        return@use session.run(aggregatedMap)
+      }
+    }
+
+    val rsr1YearProb = (
+      results["rsr_1yr_prob"]
+        .orElseThrow { ONNXResponseFailure("rsr1YearProb not returned for CRN ${offenderAndOffences.crn}") }.value as FloatArray
+      )
+
+    val rsr2YearProb = (
+      results["rsr_2yr_prob"]
+        .orElseThrow { ONNXResponseFailure("rsr2YearProb not returned for CRN ${offenderAndOffences.crn}") }.value as FloatArray
+      )
+
+    log.debug("Results: year 1 ${rsr1YearProb[0]} - year 2 ${rsr2YearProb[0]}")
+
+    val predictorResults = mapOf(PredictorSubType.RSR to Score(null, rsr1YearProb.getOrNull(0)?.toBigDecimal(), true))
+
+    return RiskPredictorsDto(
+      "ONNX-pre-release",
+      LocalDateTime.now(),
+      PredictorType.RSR,
+      ScoreType.DYNAMIC,
+      predictorResults,
+      emptyList(),
+      0
+    )
+  }
+
+  fun buildStaticTensors(offenderAndOffences: OffenderAndOffencesDto, env: OrtEnvironment): Map<String, OnnxTensor> {
+    with(offenderAndOffences) {
+      return mapOf(
+        "gender" to OnnxTensor.createTensor(env, arrayOf(gender.toOnnxFormat())),
+        "dob" to OnnxTensor.createTensor(env, getDateAsLong(dob)),
+        "currentOffence" to OnnxTensor.createTensor(env, arrayOf(currentOffence.offenceCode)),
+        "offenceSubcode" to OnnxTensor.createTensor(env, arrayOf(currentOffence.offenceSubcode)),
+        "homeOfficeCode" to OnnxTensor.createTensor(
+          env,
+          longArrayOf("${currentOffence.offenceCode}${currentOffence.offenceSubcode}".toLong())
+        ),
+        "dateOfFirstSanction" to OnnxTensor.createTensor(env, getDateAsLong(dateOfFirstSanction)),
+        "ageAtFirstSanction" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(calculateAgeAtFirstSanction(dob, dateOfFirstSanction))
+        ),
+        "totalOffences" to OnnxTensor.createTensor(env, longArrayOf(totalOffences.toLong())),
+        "totalViolentOffences" to OnnxTensor.createTensor(env, longArrayOf(totalViolentOffences.toLong())),
+        "dateOfCurrentConviction" to OnnxTensor.createTensor(env, getDateAsLong(dateOfCurrentConviction)),
+        "hasAnySexualOffences" to OnnxTensor.createTensor(env, booleanArrayOf(hasAnySexualOffences)),
+        "isCurrentSexualOffence" to OnnxTensor.createTensor(env, booleanArrayOf(isCurrentSexualOffence ?: false)),
+        "isCurrentOffenceVictimStranger" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(isCurrentOffenceVictimStranger ?: false)
+        ),
+        "mostRecentSexualOffenceDate" to OnnxTensor.createTensor(env, getDateAsLong(mostRecentSexualOffenceDate)),
+        "totalSexualOffencesInvolvingAnAdult" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(totalSexualOffencesInvolvingAnAdult?.toLong() ?: -1)
+        ),
+        "totalSexualOffencesInvolvingAChild" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(totalSexualOffencesInvolvingAChild?.toLong() ?: -1)
+        ),
+        "totalSexualOffencesInvolvingChildImages" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(totalSexualOffencesInvolvingChildImages?.toLong() ?: -1)
+        ),
+        "totalNonContactSexualOffences" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(totalNonContactSexualOffences?.toLong() ?: -1)
+        ),
+        "earliestReleaseDate" to OnnxTensor.createTensor(env, getDateAsLong(earliestReleaseDate)),
+        "hasCompletedInterview" to OnnxTensor.createTensor(env, booleanArrayOf(hasCompletedInterview))
+      )
+    }
+  }
+
+  fun buildDynamicTensors(offenderAndOffences: OffenderAndOffencesDto, env: OrtEnvironment): Map<String, OnnxTensor> {
+    with(offenderAndOffences.dynamicScoringOffences) {
+      return mapOf(
+        "hasSuitableAccommodation" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(this?.hasSuitableAccommodation?.score?.toLong() ?: -1)
+        ),
+        "employment" to OnnxTensor.createTensor(env, longArrayOf(this?.employment?.score?.toLong() ?: -1)),
+        "currentRelationshipWithPartner" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(this?.currentRelationshipWithPartner?.score?.toLong() ?: -1)
+        ),
+        "evidenceOfDomesticViolence" to OnnxTensor.createTensor(
+          env, booleanArrayOf(this?.evidenceOfDomesticViolence ?: false)
+        ),
+        "alcoholUseIssues" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(this?.alcoholUseIssues?.score?.toLong() ?: -1)
+        ),
+        "bingeDrinkingIssues" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(this?.bingeDrinkingIssues?.score?.toLong() ?: -1)
+        ),
+        "impulsivityIssues" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(this?.impulsivityIssues?.score?.toLong() ?: -1)
+        ),
+        "temperControlIssues" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(this?.temperControlIssues?.score?.toLong() ?: -1)
+        ),
+        "proCriminalAttitudes" to OnnxTensor.createTensor(
+          env,
+          longArrayOf(this?.proCriminalAttitudes?.score?.toLong() ?: -1)
+        )
+      )
+    }
+  }
+
+  fun buildPreviousOffencesTensors(
+    offenderAndOffences: OffenderAndOffencesDto,
+    env: OrtEnvironment
+  ): Map<String, OnnxTensor> {
+    with(offenderAndOffences.dynamicScoringOffences?.previousOffences) {
+      return mapOf(
+        "murderAttempt" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.murderAttempt ?: false)
+        ),
+        "wounding" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.wounding ?: false)
+        ),
+        "aggravatedBurglary" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.aggravatedBurglary ?: false)
+        ),
+        "arson" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.arson ?: false)
+        ),
+        "criminalDamage" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.criminalDamage ?: false)
+        ),
+        "kidnapping" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.kidnapping ?: false)
+        ),
+        "robbery" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.robbery ?: false)
+        ),
+        "prevfirearmPossession" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.firearmPossession ?: false)
+        ),
+        "prevoffencesWithWeapon" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.offencesWithWeapon ?: false)
+        )
+      )
+    }
+  }
+
+  fun buildCurrentOffencesTensors(
+    offenderAndOffences: OffenderAndOffencesDto,
+    env: OrtEnvironment
+  ): Map<String, OnnxTensor> {
+    with(offenderAndOffences.dynamicScoringOffences?.currentOffences) {
+      return mapOf(
+        "currentfirearmPossession" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.firearmPossession ?: false)
+        ),
+        "currentoffencesWithWeapon" to OnnxTensor.createTensor(
+          env,
+          booleanArrayOf(this?.offencesWithWeapon ?: false)
+        )
+      )
+    }
+  }
+
+  fun calculateAgeAtFirstSanction(dob: LocalDate?, dateOfFirstSanction: LocalDate?): Long {
+    if (dob == null || dateOfFirstSanction == null) return -1
+    return Period.between(dob, dateOfFirstSanction).years.toLong()
+  }
+
+  fun getDateAsLong(date: LocalDate?): LongArray {
+    if (date == null) return longArrayOf()
+    return longArrayOf(date.format(DateTimeFormatter.ofPattern("yyyyMMdd")).toLong())
+  }
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/exceptions/ApplicationsExceptions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/exceptions/ApplicationsExceptions.kt
@@ -10,6 +10,8 @@ class DuplicateSourceRecordFound(msg: String?, val supplementaryRiskDto: Supplem
   RuntimeException(msg)
 class PredictorCalculationError(msg: String?) : RuntimeException(msg)
 class IncorrectInputParametersException(msg: String?) : RuntimeException(msg)
+class ONNXResponseFailure(msg: String?) : RuntimeException(msg)
+class ONNXConsumerFailure(msg: String?) : RuntimeException(msg)
 
 // External Services Exceptions
 class ExternalApiEntityNotFoundException(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -107,3 +107,7 @@ logging:
 
 assessment-api:
   base-url: http://localhost:9004
+
+onnx-predictors:
+  enabled: false
+  onnx-path: /tmp/onnx/rsr.onnx

--- a/src/test/kotlin/ONNXTest.kt
+++ b/src/test/kotlin/ONNXTest.kt
@@ -1,0 +1,73 @@
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.CurrentOffence
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.CurrentOffences
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.DynamicScoringOffences
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.EmploymentType
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.Gender
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.OffenderAndOffencesDto
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.PreviousOffences
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.ProblemsLevel
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.services.OnnxPredictorService
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class ONNXTest {
+
+  companion object {
+    // Test method to run the ONNX predictor
+    @JvmStatic
+    fun main(args: Array<String>) {
+      val offencesAndOffencesDto = OffenderAndOffencesDto(
+        crn = "X1345",
+        gender = Gender.MALE,
+        dob = LocalDate.of(2000, 11, 11).minusYears(20),
+        assessmentDate = LocalDateTime.of(2021, 11, 11, 0, 0, 0),
+        currentOffence = CurrentOffence("001", "01"),
+        dateOfFirstSanction = LocalDate.of(2000, 11, 11).minusYears(1),
+        totalOffences = 50,
+        totalViolentOffences = 8,
+        dateOfCurrentConviction = LocalDate.of(2020, 11, 1).minusWeeks(2),
+        hasAnySexualOffences = true,
+        isCurrentSexualOffence = true,
+        isCurrentOffenceVictimStranger = true,
+        mostRecentSexualOffenceDate = LocalDate.of(2020, 10, 11).minusWeeks(3),
+        totalSexualOffencesInvolvingAnAdult = 5,
+        totalSexualOffencesInvolvingAChild = 3,
+        totalSexualOffencesInvolvingChildImages = 2,
+        totalNonContactSexualOffences = 2,
+        earliestReleaseDate = LocalDate.of(2022, 11, 11).plusMonths(10),
+        hasCompletedInterview = true,
+        dynamicScoringOffences = DynamicScoringOffences(
+          hasSuitableAccommodation = ProblemsLevel.SIGNIFICANT_PROBLEMS,
+          employment = EmploymentType.NOT_AVAILABLE_FOR_WORK,
+          currentRelationshipWithPartner = ProblemsLevel.SIGNIFICANT_PROBLEMS,
+          evidenceOfDomesticViolence = true,
+          isPerpetrator = true,
+          alcoholUseIssues = ProblemsLevel.SIGNIFICANT_PROBLEMS,
+          bingeDrinkingIssues = ProblemsLevel.SIGNIFICANT_PROBLEMS,
+          impulsivityIssues = ProblemsLevel.SIGNIFICANT_PROBLEMS,
+          temperControlIssues = ProblemsLevel.SIGNIFICANT_PROBLEMS,
+          proCriminalAttitudes = ProblemsLevel.SOME_PROBLEMS,
+          previousOffences = PreviousOffences(
+            murderAttempt = true,
+            wounding = true,
+            aggravatedBurglary = true,
+            arson = true,
+            criminalDamage = true,
+            kidnapping = true,
+            firearmPossession = true,
+            robbery = true,
+            offencesWithWeapon = true
+          ),
+          currentOffences = CurrentOffences(
+            firearmPossession = true,
+            offencesWithWeapon = true
+          )
+        )
+      )
+
+      OnnxPredictorService("/tmp/onnx/rsr.onnx").calculatePredictorScores(
+        offencesAndOffencesDto
+      )
+    }
+  }
+}


### PR DESCRIPTION
This creates service to integrate with the RSR ONNX file provided by Data Science. The file cannot be published yet and so is not part of this PR.

The current ONNX file only includes the OSP-I component on RSR but future releases will contain the full implmentation.

Notes:
- The ONNX input parameters should now be fixed
- The ONNX output parameters will change to include more detail, including a breakdown of all the RSR component parts (OSP-I, OSP-C, SNSV and the banding, currently only the rsr-year-1 and rsr-year-2 predictions are returned
- Until the ONNX file can be published it will be challenging to write good tests for the ONNX service. 
- Mocking out the ONNXRuntime will require a lot of effort and deliver little value