### PR TITLE
Create prod-to-preprod refresh job

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ SPRING_PROFILES_ACTIVE=postgres
 ### Documentation
 The generated documentation for the api can be viewed at http://localhost:8080/swagger-ui.html
 
+## Tasks
+
+❗️ This requires kubectl 1.19, as 1.20+ is incompatible with the live-1 cluster as of October 2021
+
+### Manually sync prod to pre-prod
+
+To manually trigger the production refresh job:
+```
+kubectl --namespace=hmpps-assess-risks-and-needs-prod \
+  create job --from=cronjob.batch/db-refresh-job refresh-job
+```
+
 ## Code style & formatting
 ./gradlew ktlintApplyToIdea addKtlintFormatGitPreCommitHook
 will apply ktlint styles to intellij and also add a pre-commit hook to format all changed kotlin files.

--- a/helm_deploy/hmpps-assess-risks-and-needs/templates/prod-to-preprod-refresh-job.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs/templates/prod-to-preprod-refresh-job.yaml
@@ -1,0 +1,94 @@
+{{- if .Values.is_production -}}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: db-refresh-script
+data:
+  entrypoint.sh: |-
+    #!/bin/bash
+    set -e
+
+    echo "${DB_HOST}:5432:${DB_NAME}:${DB_USER}:${DB_PASS}" > ~/.pgpass
+    echo "${DB_HOST_PREPROD}:5432:${DB_NAME_PREPROD}:${DB_USER_PREPROD}:${DB_PASS_PREPROD}" >> ~/.pgpass
+    chmod 0600 ~/.pgpass
+
+    set -x
+    pg_dump --host="$DB_HOST" --username="$DB_USER" --format=custom --no-privileges --verbose --file=/tmp/db.dump "$DB_NAME"
+    pg_restore --host="$DB_HOST_PREPROD" --username="$DB_USER_PREPROD" --clean --no-owner --verbose --dbname="$DB_NAME_PREPROD" /tmp/db.dump
+
+    rm -v /tmp/db.dump ~/.pgpass
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: db-refresh-job
+spec:
+  schedule: "0 8 * * 0"
+  concurrencyPolicy: "Forbid"
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      activeDeadlineSeconds: 1200
+      template:
+        spec:
+          securityContext:
+            runAsUser: 999
+          containers:
+            - name: dbrefresh
+              image: "postgres:10"
+              command:
+                - /bin/entrypoint.sh
+              volumeMounts:
+                - name: db-refresh-script
+                  mountPath: /bin/entrypoint.sh
+                  readOnly: true
+                  subPath: entrypoint.sh
+              env:
+                - name: DB_NAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-assess-risks-and-needs-rds-instance
+                      key: database_name
+                - name: DB_USER
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-assess-risks-and-needs-rds-instance
+                      key: database_username
+                - name: DB_PASS
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-assess-risks-and-needs-rds-instance
+                      key: database_password
+                - name: DB_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: hmpps-assess-risks-and-needs-rds-instance
+                      key: rds_instance_address
+                - name: DB_NAME_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: preprod-rds-instance
+                      key: database_name
+                - name: DB_USER_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: preprod-rds-instance
+                      key: database_username
+                - name: DB_PASS_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: preprod-rds-instance
+                      key: database_password
+                - name: DB_HOST_PREPROD
+                  valueFrom:
+                    secretKeyRef:
+                      name: preprod-rds-instance
+                      key: rds_instance_address
+          restartPolicy: "Never"
+          volumes:
+            - name: db-refresh-script
+              configMap:
+                name: db-refresh-script
+                defaultMode: 0755
+{{- end }}

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -18,3 +18,5 @@ generic-prometheus-alerts:
 
 dataExtractor:
   enabled: false
+
+is_production: true


### PR DESCRIPTION
## What does this pull request do?

Create a scheduled prod-to-preprod refresh job

It runs on every Sunday at 8 am (UTC)

## Why?

`hmpps-interventions-service` references data in this service and it also
does a weekly refresh. To maintain data integrity in the pre-prod
environment, identifiers should be synced across

It is currently safe to copy all data from production to pre-production.
However, this process also allows follow-up obfuscation/transformations
to happen later, if desired

## Depends on

- https://github.com/ministryofjustice/cloud-platform-environments/pull/5812

## Related to

- https://github.com/ministryofjustice/hmpps-interventions-service/pull/564