### PR TITLE
:bug: fix RiskService to handle null ROSH levels

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/RoshRiskSummaryDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/RoshRiskSummaryDto.kt
@@ -48,7 +48,7 @@ data class RiskRoshSummaryDto(
       "}"
   )
   @JsonView(View.CrsProvider::class, View.RiskView::class)
-  val riskInCommunity: Map<RiskLevel, List<String>> = hashMapOf(),
+  val riskInCommunity: Map<RiskLevel?, List<String>> = hashMapOf(),
 
   @Schema(
     description = "Assess the risk of serious harm the offender poses on the basis that they could be released imminently back into the community." +
@@ -61,7 +61,7 @@ data class RiskRoshSummaryDto(
       "}"
   )
   @JsonView(View.Probation::class, View.RiskView::class)
-  val riskInCustody: Map<RiskLevel, List<String>> = hashMapOf(),
+  val riskInCustody: Map<RiskLevel?, List<String>> = hashMapOf(),
 
   @Schema(description = "The date and time that the assessment was completed")
   @JsonView(View.Probation::class, View.SingleRisksView::class)
@@ -75,8 +75,9 @@ enum class RiskLevel(
   VERY_HIGH("Very High"), HIGH("High"), MEDIUM("Medium"), LOW("Low");
 
   companion object {
-    fun fromString(enumValue: String?): RiskLevel {
-      return values().firstOrNull { it.value == enumValue }
+    fun fromString(enumValue: String?): RiskLevel? {
+      return if (enumValue == null) null
+      else values().firstOrNull { it.value == enumValue }
         ?: throw IllegalArgumentException("Unknown Risk Level $enumValue")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskService.kt
@@ -69,7 +69,7 @@ class RiskService(private val assessmentClient: AssessmentApiRestClient) {
     )
   }
 
-  private fun Collection<QuestionAnswerDto>?.toRiskInCustody(): Map<RiskLevel, List<String>> {
+  private fun Collection<QuestionAnswerDto>?.toRiskInCustody(): Map<RiskLevel?, List<String>> {
     val children = RiskLevel.fromString(findAnswer(RoshQuestionCodes.CHILDREN_IN_CUSTODY_RISK, this)?.staticText)
     val public = RiskLevel.fromString(findAnswer(RoshQuestionCodes.PUBLIC_IN_CUSTODY_RISK, this)?.staticText)
     val knowAdult = RiskLevel.fromString(findAnswer(RoshQuestionCodes.KNOWN_ADULT_IN_CUSTODY_RISK, this)?.staticText)
@@ -82,10 +82,10 @@ class RiskService(private val assessmentClient: AssessmentApiRestClient) {
       "Known Adult" to knowAdult,
       "Staff" to staff,
       "Prisoners" to prisoners
-    ).groupBy({ it.second }, { it.first })
+    ).groupBy({ it.second }, { it.first }).filterKeys { it != null }
   }
 
-  private fun Collection<QuestionAnswerDto>?.toRiskInCommunity(): Map<RiskLevel, List<String>> {
+  private fun Collection<QuestionAnswerDto>?.toRiskInCommunity(): Map<RiskLevel?, List<String>> {
     val children = RiskLevel.fromString(findAnswer(RoshQuestionCodes.CHILDREN_IN_COMMUNITY_RISK, this)?.staticText)
     val public = RiskLevel.fromString(findAnswer(RoshQuestionCodes.PUBLIC_IN_COMMUNITY_RISK, this)?.staticText)
     val knowAdult = RiskLevel.fromString(findAnswer(RoshQuestionCodes.KNOWN_ADULT_IN_COMMUNITY_RISK, this)?.staticText)
@@ -95,7 +95,7 @@ class RiskService(private val assessmentClient: AssessmentApiRestClient) {
       "Public" to public,
       "Known Adult" to knowAdult,
       "Staff" to staff
-    ).groupBy({ it.second }, { it.first })
+    ).groupBy({ it.second }, { it.first }).filterKeys { it != null }
   }
 
   private fun SectionAnswersDto?.toOtherRoshRisksDto(): OtherRoshRisksDto {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskControllerTest.kt
@@ -286,4 +286,33 @@ class RiskControllerTest : IntegrationTestBase() {
         )
       }
   }
+
+  @Test
+  fun `allow null rosh scores`() {
+    val crn = "X234567"
+    webTestClient.get().uri("/risks/crn/$crn")
+      .headers(setAuthorisation(roles = listOf("ROLE_PROBATION")))
+      .exchange()
+      .expectStatus().isOk
+      .expectBody<AllRoshRiskDto>()
+      .consumeWith {
+        assertThat(it.responseBody.summary).isEqualTo(
+          RiskRoshSummaryDto(
+            "whoisAtRisk",
+            "natureOfRisk",
+            "riskImminence",
+            "riskIncreaseFactors",
+            "riskMitigationFactors",
+            mapOf(
+              RiskLevel.LOW to listOf("Known Adult"),
+              RiskLevel.MEDIUM to listOf("Public"),
+            ),
+            mapOf(
+              RiskLevel.LOW to listOf("Public", "Known Adult")
+            ),
+            assessedOn = null
+          )
+        )
+      }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/testutils/AssessmentApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/testutils/AssessmentApiMockServer.kt
@@ -7,6 +7,7 @@ import com.github.tomakehurst.wiremock.http.HttpHeaders
 
 class AssessmentApiMockServer : WireMockServer(9004) {
   private val crn = "X123456"
+  private val missingRoshCrn = "X234567"
   fun stubGetRoshRisksByCrn() {
     stubFor(
       WireMock.post(
@@ -48,6 +49,27 @@ class AssessmentApiMockServer : WireMockServer(9004) {
             .withBody(crnNotFoundJson)
             .withStatus(404)
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+        )
+    )
+
+    stubFor(
+      WireMock.post(
+        WireMock.urlEqualTo(
+          "/assessments/crn/$missingRoshCrn/sections/answers?assessmentStatus=COMPLETE" +
+            "&assessmentTypes=LAYER_1,LAYER_3&period=YEAR&periodUnits=1"
+        )
+      )
+        .withRequestBody(
+          WireMock.equalToJson(
+            "{ \"sectionCodes\": [\"ROSH_SCREENING\", \"ROSH_FULL_ANALYSIS\", \"ROSH_SUMMARY\"]}",
+            true,
+            true
+          )
+        )
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(assessmentJsonMissingRoshData)
         )
     )
   }
@@ -684,4 +706,283 @@ class AssessmentApiMockServer : WireMockServer(9004) {
     ]
     
   """.trimIndent()
+
+  private val assessmentJsonMissingRoshData =
+
+    """{
+    "assessmentId": 9479348,
+    "sections": {
+        "ROSH": [
+            {
+                "refQuestionCode": "R2.1",
+                "questionText": "Is the offender, now or on release, likely to live with, or have frequent contact with, any child who is on the child protection register or is being looked after by the local authority.",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "R2.2",
+                "questionText": "Are there any concerns in relation to children",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "R2.2.1",
+                "questionText": "Should contact be made with social services",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "R3.1",
+                "questionText": "Risk of suicide",
+                "refAnswerCode": "NO",
+                "staticText": "No"
+            },
+            {
+                "refQuestionCode": "R3.2",
+                "questionText": "Risk of self-harm",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "R3.3",
+                "questionText": "Coping in custody / hostel setting",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "R3.4",
+                "questionText": "Vulnerability",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "R4.1",
+                "questionText": "Escape / abscond",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "R4.2",
+                "questionText": "Control issues / disruptive behaviour",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "R4.3",
+                "questionText": "Concerns in respect of breach of trust",
+                "refAnswerCode": "DK",
+                "staticText": "Don't know"
+            },
+            {
+                "refQuestionCode": "R4.4",
+                "questionText": "Risks to other prisoners",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            }
+        ],
+        "ROSHFULL": [
+            {
+                "refQuestionCode": "FA1",
+                "questionText": "Offence details",
+                "freeFormText": "shjkhsdjhkjshfkjshdkfjhskjdhkjhkjhkj"
+            },
+            {
+                "refQuestionCode": "FA16",
+                "questionText": "b) is involved in a situation where there are identifiable children who are considered to be at risk from others",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA2",
+                "questionText": "Where and when did s/he do it",
+                "freeFormText": "klsdjkljlksd"
+            },
+            {
+                "refQuestionCode": "FA3",
+                "questionText": "How did s/he do it (was there any pre planning, use of weapon, tool etc)",
+                "freeFormText": "sdlljsd;ljf;lds"
+            },
+            {
+                "refQuestionCode": "FA31",
+                "questionText": "Are there any current concerns about suicide",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA32",
+                "questionText": "Are there any current concerns about self-harm",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA33",
+                "questionText": "Describe circumstances, relevant issues and needs regarding current concerns (refer to sections 1-12 for indicators, particularly Section 10)",
+                "freeFormText": "Suicide and/or Self-harm current concerns"
+            },
+            {
+                "refQuestionCode": "FA34",
+                "questionText": "Is there a current ACCT (Assessment, Care in Custody and Teamwork?)",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA36",
+                "questionText": "Have there been any concerns about suicide in the past",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA37",
+                "questionText": "Have there been any concerns about self-harm in the past",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA39",
+                "questionText": "Are there any current concerns about coping in custody",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA4",
+                "questionText": "Who were the victims (are there concerns about targeting, type, age, race of vulnerability or victim)",
+                "freeFormText": "sdflkl;sdkjf;l"
+            },
+            {
+                "refQuestionCode": "FA40",
+                "questionText": "Are there any current concerns about coping in hostel settings",
+                "refAnswerCode": "NO",
+                "staticText": "No"
+            },
+            {
+                "refQuestionCode": "FA41",
+                "questionText": "Describe circumstances, relevant issues and needs",
+                "freeFormText": "Coping in custody / hostel setting current concerns"
+            },
+            {
+                "refQuestionCode": "FA42",
+                "questionText": "Are there any previous concerns about coping in custody",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA43",
+                "questionText": "Are there any previous concerns about coping in hostel settings",
+                "refAnswerCode": "NO",
+                "staticText": "No"
+            },
+            {
+                "refQuestionCode": "FA44",
+                "questionText": "Describe circumstances, relevant issues and needs",
+                "freeFormText": "Coping in custody / hostel setting previous concerns"
+            },
+            {
+                "refQuestionCode": "FA45",
+                "questionText": "Are there any current concerns about vulnerability (eg victimisation, being bullied, assaulted, exploited)",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA45.t",
+                "questionText": "Describe circumstances, relevant issues and needs",
+                "freeFormText": "Vulnerability current concerns free text"
+            },
+            {
+                "refQuestionCode": "FA47",
+                "questionText": "Have there been any previous concerns about vulnerability (eg victimisation, being bullied, assaulted, exploited)",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA47.t",
+                "questionText": "Describe circumstances, relevant issues and needs",
+                "freeFormText": "Vulnerability previous concerns free text"
+            },
+            {
+                "refQuestionCode": "FA49",
+                "questionText": " Do any of the above (R8.1 - 8.3) indicate a risk of serious harm to others.  If YES complete the risk of serious harm analysis, R6",
+                "refAnswerCode": "YES",
+                "staticText": "Yes"
+            },
+            {
+                "refQuestionCode": "FA49.t",
+                "questionText": "Describe circumstances, relevant issues and needs",
+                "freeFormText": "Risk of serious harm free text"
+            },
+            {
+                "refQuestionCode": "FA5",
+                "questionText": "Was anyone else present / involved",
+                "freeFormText": "sflk;ljkf;lds"
+            },
+            {
+                "refQuestionCode": "FA6",
+                "questionText": "Why did s/he do it (motivation and triggers)",
+                "freeFormText": "sfkjlj"
+            },
+            {
+                "refQuestionCode": "FA7",
+                "questionText": "Sources of information",
+                "freeFormText": "fshjkjhk"
+            }
+        ],
+        "ROSHSUM": [
+            {
+                "refQuestionCode": "SUM1",
+                "questionText": "Who is at risk",
+                "freeFormText": "whoisAtRisk"
+            },
+            {
+                "refQuestionCode": "SUM2",
+                "questionText": "What is the nature of the risk",
+                "freeFormText": "natureOfRisk"
+            },
+            {
+                "refQuestionCode": "SUM3",
+                "questionText": "When is the risk likely to be greatest\nConsider the timescale and indicate whether risk is immediate or not.  Consider the risks in custody as well as on release.\n",
+                "freeFormText": "riskImminence"
+            },
+            {
+                "refQuestionCode": "SUM4",
+                "questionText": "What circumstances are likely to increase risk\nDescribe factors, actions, events which might increase level of risk, now and in the future\n",
+                "freeFormText": "riskIncreaseFactors"
+            },
+            {
+                "refQuestionCode": "SUM5",
+                "questionText": "What factors are likely to reduce the risk\nDescribe factors, actions, and events which may reduce or contain the level of risk. What has previously stopped him / her?  ",
+                "freeFormText": "riskMitigationFactors"
+            },
+            {
+                "refQuestionCode": "SUM6.2.1",
+                "questionText": "Risk in Community",
+                "refAnswerCode": "M",
+                "staticText": "Medium"
+            },
+            {
+                "refQuestionCode": "SUM6.2.2",
+                "questionText": "Risk in Custody",
+                "refAnswerCode": "L",
+                "staticText": "Low"
+            },
+            {
+                "refQuestionCode": "SUM6.3.1",
+                "questionText": "Risk in Community",
+                "refAnswerCode": "L",
+                "staticText": "Low"
+            },
+            {
+                "refQuestionCode": "SUM6.3.2",
+                "questionText": "Risk in Custody",
+                "refAnswerCode": "L",
+                "staticText": "Low"
+            },
+            {
+                "refQuestionCode": "SUM8",
+                "questionText": "If necessary record the details of any key documents or reports used in this analysis:",
+                "freeFormText": "zccx"
+            }
+        ]
+    },
+    "assessedOn": "2021-06-21T15:55:04"
+}
+    """.trimIndent()
 }


### PR DESCRIPTION
Bug Fix: Older OASys assessments may have null answers for ROSH questions. At present this causes `IllegalArgumentException: Unknown Risk Level null`

This PR removes handles null score levels and returns the map of score levels for community and custody risks with null levels removed. 
e.g. if scores were entered for Known Adult, Staff, and Prisoners but NO scores for Public or Children: it returns the following map:
```
{
    "HIGH" : ["Known Adult", "Prisoners"],
    "MEDIUM" : ["Staff"]
}
```