### PR TITLE
Update data extractor job to use the V1 image

### DIFF
--- a/helm_deploy/hmpps-assess-risks-and-needs/templates/data-extractor-job.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs/templates/data-extractor-job.yaml
@@ -23,7 +23,7 @@ spec:
           restartPolicy: "Never"
           containers:
             - name: data-extractor-analytics
-              image: ministryofjustice/data-engineering-data-extractor:develop
+              image: ministryofjustice/data-engineering-data-extractor:v1
               imagePullPolicy: Always
               args: ["extract_table_names.py && extract_pg_jsonl_snapshot.py && transfer_local_to_s3.sh"]
               env:


### PR DESCRIPTION
In response to a message received from the AP team.

```
if not already using it, could you please switch to the v1 version:
ministryofjustice/data-engineering-data-extractor:v1
```