### PR TITLE
ARN-884-handle-null-rsr

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/RiskPredictorsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/RiskPredictorsDto.kt
@@ -39,7 +39,7 @@ enum class ScoreType(val type: String) {
   STATIC("Static"), DYNAMIC("Dynamic");
 
   companion object {
-    fun findByType(type: String): ScoreType? {
+    fun findByType(type: String?): ScoreType? {
       return values().firstOrNull { value -> value.type == type }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/RiskPredictorsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/RiskPredictorsDto.kt
@@ -39,7 +39,7 @@ enum class ScoreType(val type: String) {
   STATIC("Static"), DYNAMIC("Dynamic");
 
   companion object {
-    fun findByType(type: String?): ScoreType? {
+    fun findByType(type: String): ScoreType? {
       return values().firstOrNull { value -> value.type == type }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/restclient/api/OasysPredictorsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/restclient/api/OasysPredictorsDto.kt
@@ -15,7 +15,14 @@ class OasysPredictorsDto(
   val rsr: RsrDto? = null,
   val osp: OspDto? = null
 
-)
+) {
+  fun hasRsrScores(): Boolean {
+    return rsr?.rsrPercentageScore != null
+      && rsr.rsrStaticOrDynamic != null
+      && rsr.rsrAlgorithmVersion != null
+      && rsr.rsrRiskRecon != null
+  }
+}
 
 class RsrDto(
   val rsrPercentageScore: BigDecimal? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/restclient/api/OasysPredictorsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/restclient/api/OasysPredictorsDto.kt
@@ -17,10 +17,10 @@ class OasysPredictorsDto(
 
 ) {
   fun hasRsrScores(): Boolean {
-    return rsr?.rsrPercentageScore != null
-      && rsr.rsrStaticOrDynamic != null
-      && rsr.rsrAlgorithmVersion != null
-      && rsr.rsrRiskRecon != null
+    return rsr?.rsrPercentageScore != null &&
+      rsr.rsrStaticOrDynamic != null &&
+      rsr.rsrAlgorithmVersion != null &&
+      rsr.rsrRiskRecon != null
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskPredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskPredictorService.kt
@@ -199,7 +199,7 @@ class RiskPredictorService(
 
   private fun getRsrScoresFromOasys(crn: String): List<RsrPredictorDto> {
     val oasysPredictors = assessmentClient.getPredictorScoresForOffender(crn) ?: emptyList()
-    val oasysRsrPredictors = oasysPredictors.filter { it.assessmentCompleted == true && it.rsr != null }
+    val oasysRsrPredictors = oasysPredictors.filter { it.assessmentCompleted == true && it.hasRsrScores() }
     log.info("Retrieved ${oasysRsrPredictors.size} RSR scores from OASys")
     return RsrPredictorDto.from(oasysRsrPredictors)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/IntegrationTestBase.kt
@@ -36,6 +36,7 @@ abstract class IntegrationTestBase {
       assessmentApiMockServer.stubGetLatestNeedsByCrn()
       assessmentApiMockServer.stubGetRSRPredictorScoring()
       assessmentApiMockServer.stubGetOffenderPredictors()
+      assessmentApiMockServer.stubGetOffenderPredictorsNoRsr()
     }
 
     @AfterAll

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
@@ -260,5 +260,6 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       .expectStatus().isEqualTo(HttpStatus.OK)
       .expectBody<List<RsrPredictorDto>>()
       .returnResult().responseBody
+    assertThat(rsrHistory).hasSize(1)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
@@ -248,4 +248,17 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       assertThat(algorithmVersion).isEqualTo("3")
     }
   }
+
+  @Test
+  fun `get all rsr score history for a crn when no rsr returned from assessment API`() {
+    val crn = "X234567"
+    val rsrHistory = webTestClient.get()
+      .uri("/risks/crn/$crn/predictors/rsr/history")
+      .header("Content-Type", "application/json")
+      .headers(setAuthorisation(user = "Gary C", roles = listOf("ROLE_PROBATION")))
+      .exchange()
+      .expectStatus().isEqualTo(HttpStatus.OK)
+      .expectBody<List<RsrPredictorDto>>()
+      .returnResult().responseBody
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
@@ -260,6 +260,6 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       .expectStatus().isEqualTo(HttpStatus.OK)
       .expectBody<List<RsrPredictorDto>>()
       .returnResult().responseBody
-    assertThat(rsrHistory).hasSize(1)
+    assertThat(rsrHistory).isEmpty()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/testutils/AssessmentApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/testutils/AssessmentApiMockServer.kt
@@ -233,6 +233,21 @@ class AssessmentApiMockServer : WireMockServer(9004) {
     )
   }
 
+  fun stubGetOffenderPredictorsNoRsr() {
+    stubFor(
+      WireMock.get(
+        WireMock.urlEqualTo(
+          "/offenders/crn/$missingRoshCrn/predictors"
+        )
+      )
+        .willReturn(
+          WireMock.aResponse()
+            .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))
+            .withBody(noRsrPredictorsJson)
+        )
+    )
+  }
+
   companion object {
     val crnNotFoundJson =
       """{ "status": 404 , "developerMessage": "Latest COMPLETE with types [LAYER_1, LAYER_3] type not found for crn, RANDOMCRN" }""".trimIndent()
@@ -701,6 +716,26 @@ class AssessmentApiMockServer : WireMockServer(9004) {
                   "description": "High"
               }
           },
+          "osp": {}
+      }
+    ]
+    
+  """.trimIndent()
+
+  private val noRsrPredictorsJson = """
+    [
+      {
+          "oasysSetId": 9519347,
+          "refAssessmentVersionCode": "LAYER1",
+          "refAssessmentVersionNumber": "2",
+          "refAssessmentId": 10,
+          "completedDate": "2021-06-21T15:55:04",
+          "assessmentCompleted": true,
+          "assessmentStatus": "COMPLETE",
+          "ogr3": {},
+          "ovp": {},
+          "ogp": {},
+          "rsr": {},
           "osp": {}
       }
     ]


### PR DESCRIPTION
This PR fixes a bug which was raised where one of the risk endpoints throws an exception when the latest assessment has an empty RSR score from OASys.

This fix adds a check for null fields in the RSR score from OASys and does not return anything where all fields are null. 