### PR TITLE
Update calculated severity example API documentation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/AssessmentNeedsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/AssessmentNeedsDto.kt
@@ -52,7 +52,7 @@ data class AssessmentNeedDto(
   val riskOfReoffending: Boolean? = null,
   @Schema(description = "Whether the section has been flagged as a low scoring need", example = "true")
   val flaggedAsNeed: Boolean? = null,
-  @Schema(description = "The calculated severity of the need", example = "true")
+  @Schema(description = "The calculated severity of the need", example = "SEVERE")
   val severity: NeedSeverity? = null,
   @Schema(description = "Whether the section questions indicate that this section is a need", example = "true")
   val identifiedAsNeed: Boolean? = null,


### PR DESCRIPTION
The calculated severity of the need currently suggests that this is a boolean value, not an enum.
