### PR TITLE
Update K8s cron resources to use batch/v1 API

### DIFF
--- a/helm_deploy/hmpps-assess-risks-and-needs/templates/data-extractor-job.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs/templates/data-extractor-job.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.dataExtractor.enabled -}}
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: {{ .Release.Name }}-analytics-extractor

--- a/helm_deploy/hmpps-assess-risks-and-needs/templates/prod-to-preprod-refresh-job.yaml
+++ b/helm_deploy/hmpps-assess-risks-and-needs/templates/prod-to-preprod-refresh-job.yaml
@@ -19,7 +19,7 @@ data:
 
     rm -v /tmp/db.dump ~/.pgpass
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: db-refresh-job


### PR DESCRIPTION
As per https://kubernetes.io/docs/reference/using-api/deprecation-guide/#cronjob-v125

```
The batch/v1beta1 API version of CronJob is no longer served as of v1.25.

- Migrate manifests and API clients to use the batch/v1 API version, available since v1.21.
- All existing persisted objects are accessible via the new API
- No notable changes
```