### PR TITLE
PI-4421 Allow clients to request standalone risk scores

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/IntegrationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/IntegrationController.kt
@@ -14,6 +14,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AllPredictorVersioned
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AllRoshRiskDto
@@ -102,7 +103,10 @@ class IntegrationController(
     @Parameter(description = "Identifier Value", required = true)
     @PathVariable
     identifierValue: String,
-  ): List<AllPredictorVersioned<Any>> = riskPredictorService.getAllRiskScoresWithoutLaoCheck(identifierType, identifierValue)
+    @Parameter(description = "Include standalone assessments. Defaults to false.", required = false)
+    @RequestParam(defaultValue = "false")
+    includeStandaloneAssessments: Boolean = false,
+  ): List<AllPredictorVersioned<Any>> = riskPredictorService.getAllRiskScoresWithoutLaoCheck(identifierType, identifierValue, includeStandaloneAssessments)
 
   @RequestMapping(path = ["/risks/rosh/{crn}"], method = [RequestMethod.GET])
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/RiskPredictorsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/RiskPredictorsController.kt
@@ -14,6 +14,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestMethod
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AllPredictorVersioned
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.IdentifierType
@@ -155,7 +156,10 @@ class RiskPredictorsController(private val riskPredictorService: RiskPredictorSe
     @Parameter(description = "Identifier Value", required = true)
     @PathVariable
     identifierValue: String,
-  ): List<AllPredictorVersioned<Any>> = riskPredictorService.getAllRiskScores(identifierType, identifierValue)
+    @Parameter(description = "Include standalone assessments. Defaults to false.", required = false)
+    @RequestParam(defaultValue = "false")
+    includeStandaloneAssessments: Boolean = false,
+  ): List<AllPredictorVersioned<Any>> = riskPredictorService.getAllRiskScores(identifierType, identifierValue, includeStandaloneAssessments)
 
   @RequestMapping(path = ["/assessments/id/{id}/risk/predictors/all"], method = [RequestMethod.GET])
   @Operation(description = GET_ALL_RISK_SCORES_BY_ASSESSMENT_ID_DESC)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/AssessmentType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/model/AssessmentType.kt
@@ -3,4 +3,5 @@ package uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model
 enum class AssessmentType {
   LAYER3,
   LAYER1,
+  STANDALONE,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskPredictorService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskPredictorService.kt
@@ -16,7 +16,6 @@ import uk.gov.justice.digital.hmpps.assessrisksandneeds.config.RequestData
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.restclient.CommunityApiRestClient
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.restclient.OasysApiRestClient
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.restclient.api.RisksCrAssPredictorAssessmentDto
-import kotlin.collections.sortedByDescending
 
 @Service
 class RiskPredictorService(
@@ -70,19 +69,33 @@ class RiskPredictorService(
     return RiskScoresDto.from(oasysRiskPredictorsDto)
   }
 
-  fun getAllRiskScores(identifierType: IdentifierType, identifierValue: String): List<AllPredictorVersioned<Any>> {
+  fun getAllRiskScores(
+    identifierType: IdentifierType,
+    identifierValue: String,
+    includeStandaloneAssessments: Boolean,
+  ): List<AllPredictorVersioned<Any>> {
     log.debug("Entered getAllRiskScores for ${identifierType.value}: $identifierValue")
     communityClient.verifyUserAccess(identifierValue, RequestData.getUserName())
-    return getAllRiskScoresWithoutLaoCheck(identifierType, identifierValue)
+    return getAllRiskScoresWithoutLaoCheck(identifierType, identifierValue, includeStandaloneAssessments)
   }
 
-  fun getAllRiskScoresWithoutLaoCheck(identifierType: IdentifierType, identifierValue: String): List<AllPredictorVersioned<Any>> {
+  fun getAllRiskScoresWithoutLaoCheck(
+    identifierType: IdentifierType,
+    identifierValue: String,
+    includeStandaloneAssessments: Boolean,
+  ): List<AllPredictorVersioned<Any>> {
     log.debug("Entered getAllRiskScoresWithoutLaoCheck for ${identifierType.value}: $identifierValue")
     auditService.sendEvent(EventType.ACCESSED_RISK_PREDICTORS, mapOf(identifierType.value to identifierValue))
     val oasysRiskPredictorsDto = oasysClient.getRiskPredictorsForCompletedAssessments(identifierValue)
     return oasysRiskPredictorsDto
       ?.assessments
-      ?.filter { it.assessmentType in listOf("LAYER3", "LAYER1") }
+      ?.filter {
+        it.assessmentType in listOfNotNull(
+          "LAYER3",
+          "LAYER1",
+          "STANDALONE".takeIf { includeStandaloneAssessments },
+        )
+      }
       ?.map { assessment ->
         val version = assessment.rsrScoreDto.rsrAlgorithmVersion?.toIntOrNull()
         // If version is null, it's a legacy assessment

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/LatestRiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/LatestRiskPredictorsControllerTest.kt
@@ -258,6 +258,28 @@ class LatestRiskPredictorsControllerTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `should include standalone assessments when requested`() {
+    // Given
+    val identifierType = "crn"
+    val identifierValue = "X123456"
+
+    // When
+    webTestClient.get()
+      .uri("/risks/predictors/all/$identifierType/$identifierValue?includeStandaloneAssessments=true")
+      .header("Content-Type", "application/json")
+      .headers(setAuthorisation(user = "assess-risks-needs", roles = listOf("ROLE_PROBATION")))
+      .exchange()
+      // Then
+      .expectStatus().isEqualTo(HttpStatus.OK)
+      .expectBody<List<AllPredictorVersioned<Any>>>()
+      .consumeWith { response ->
+        assertThat(response.responseBody)
+          .hasSize(6)
+          .anyMatch { it.assessmentType == AssessmentType.STANDALONE }
+      }
+  }
+
+  @Test
   fun `should return not found error for invalid crn for versioned risk scores`() {
     webTestClient.get().uri("/risks/predictors/all/crn/X999999")
       .headers(setAuthorisation(roles = listOf("ROLE_PROBATION")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/integration/RiskPredictorsControllerTest.kt
@@ -58,10 +58,20 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       .expectBody<List<RsrPredictorVersioned<Any>>>()
       .returnResult().responseBody
 
-    assertThat(rsrScores).hasSize(5)
+    assertThat(rsrScores).hasSize(6)
     assertThat(rsrScores[0].outputVersion).isEqualTo("2")
-    val firstLegacyRsrScore = rsrScores[0] as RsrPredictorVersionedDto
-    with(firstLegacyRsrScore) {
+    val standaloneRsrScore = rsrScores[0] as RsrPredictorVersionedDto
+    with(standaloneRsrScore) {
+      assertThat(completedDate).isEqualTo(LocalDateTime.of(2026, 7, 27, 15, 40, 41))
+      assertThat(source).isEqualTo(RsrScoreSource.OASYS)
+      assertThat(status).isEqualTo(AssessmentStatus.COMPLETE)
+      assertThat(output?.combinedSeriousReoffendingPredictor?.score).isEqualTo(BigDecimal.valueOf(1.79))
+      assertThat(output?.combinedSeriousReoffendingPredictor?.band).isEqualTo(ScoreLevel.MEDIUM)
+      assertThat(output?.combinedSeriousReoffendingPredictor?.staticOrDynamic).isEqualTo(ScoreType.STATIC)
+    }
+    assertThat(rsrScores[1].outputVersion).isEqualTo("2")
+    val secondVersionedRsrScore = rsrScores[1] as RsrPredictorVersionedDto
+    with(secondVersionedRsrScore) {
       assertThat(completedDate).isEqualTo(LocalDateTime.of(2022, 6, 12, 18, 23, 20))
       assertThat(source).isEqualTo(RsrScoreSource.OASYS)
       assertThat(status).isEqualTo(AssessmentStatus.COMPLETE)
@@ -69,9 +79,9 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       assertThat(output?.combinedSeriousReoffendingPredictor?.band).isEqualTo(ScoreLevel.LOW)
       assertThat(output?.combinedSeriousReoffendingPredictor?.staticOrDynamic).isEqualTo(ScoreType.STATIC)
     }
-    assertThat(rsrScores[2].outputVersion).isEqualTo("1")
-    val thirdLegacyRsrScore = rsrScores[2] as RsrPredictorVersionedLegacyDto
-    with(thirdLegacyRsrScore) {
+    assertThat(rsrScores[3].outputVersion).isEqualTo("1")
+    val fourthLegacyRsrScore = rsrScores[3] as RsrPredictorVersionedLegacyDto
+    with(fourthLegacyRsrScore) {
       assertThat(completedDate).isEqualTo(LocalDateTime.of(2022, 6, 10, 18, 23, 20))
       assertThat(source).isEqualTo(RsrScoreSource.OASYS)
       assertThat(status).isEqualTo(AssessmentStatus.COMPLETE)
@@ -79,9 +89,9 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       assertThat(output?.rsrScoreLevel).isEqualTo(ScoreLevel.MEDIUM)
       assertThat(output?.staticOrDynamic).isEqualTo(ScoreType.DYNAMIC)
     }
-    assertThat(rsrScores[4].outputVersion).isEqualTo("1")
-    val fifthLegacyRsrScore = rsrScores[4] as RsrPredictorVersionedLegacyDto
-    with(fifthLegacyRsrScore) {
+    assertThat(rsrScores[5].outputVersion).isEqualTo("1")
+    val sixthLegacyRsrScore = rsrScores[5] as RsrPredictorVersionedLegacyDto
+    with(sixthLegacyRsrScore) {
       assertThat(completedDate).isEqualTo(LocalDateTime.of(2022, 4, 27, 12, 46, 39))
       assertThat(source).isEqualTo(RsrScoreSource.OASYS)
       assertThat(status).isEqualTo(AssessmentStatus.COMPLETE)
@@ -131,8 +141,16 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       .expectBody<List<RsrPredictorDto>>()
       .returnResult().responseBody
 
-    assertThat(rsrHistory).hasSize(5)
+    assertThat(rsrHistory).hasSize(6)
     with(rsrHistory[0]) {
+      assertThat(rsrPercentageScore).isEqualTo(BigDecimal.valueOf(1.79))
+      assertThat(rsrScoreLevel).isEqualTo(ScoreLevel.MEDIUM)
+      assertThat(completedDate).isEqualTo(LocalDateTime.of(2026, 7, 27, 15, 40, 41))
+      assertThat(staticOrDynamic).isEqualTo(ScoreType.STATIC)
+      assertThat(source).isEqualTo(RsrScoreSource.OASYS)
+      assertThat(status).isEqualTo(AssessmentStatus.COMPLETE)
+    }
+    with(rsrHistory[1]) {
       assertThat(rsrPercentageScore).isEqualTo(BigDecimal.valueOf(1.23))
       assertThat(rsrScoreLevel).isEqualTo(ScoreLevel.LOW)
       assertThat(completedDate).isEqualTo(LocalDateTime.of(2022, 6, 12, 18, 23, 20))
@@ -140,7 +158,7 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       assertThat(source).isEqualTo(RsrScoreSource.OASYS)
       assertThat(status).isEqualTo(AssessmentStatus.COMPLETE)
     }
-    with(rsrHistory[2]) {
+    with(rsrHistory[3]) {
       assertThat(rsrPercentageScore).isEqualTo(BigDecimal.valueOf(50.1234))
       assertThat(rsrScoreLevel).isEqualTo(ScoreLevel.MEDIUM)
       assertThat(completedDate).isEqualTo(LocalDateTime.of(2022, 6, 10, 18, 23, 20))
@@ -148,7 +166,7 @@ class RiskPredictorsControllerTest : IntegrationTestBase() {
       assertThat(source).isEqualTo(RsrScoreSource.OASYS)
       assertThat(status).isEqualTo(AssessmentStatus.COMPLETE)
     }
-    with(rsrHistory[4]) {
+    with(rsrHistory[5]) {
       assertThat(rsrPercentageScore).isEqualTo(BigDecimal.valueOf(0.32))
       assertThat(rsrScoreLevel).isEqualTo(ScoreLevel.LOW)
       assertThat(calculatedDate).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskPredictorServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/services/RiskPredictorServiceTest.kt
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.slf4j.MDC
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AssessmentStatus
+import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.AssessmentType
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.CaseAccess
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.IdentifierType
 import uk.gov.justice.digital.hmpps.assessrisksandneeds.api.model.RiskScoresDto
@@ -159,7 +160,7 @@ class RiskPredictorServiceTest {
       }.returns(allRisksOasysRiskPredictorsDto)
 
       // When
-      val allRiskScores = riskPredictorsService.getAllRiskScoresWithoutLaoCheck(IdentifierType.CRN, crn)
+      val allRiskScores = riskPredictorsService.getAllRiskScoresWithoutLaoCheck(IdentifierType.CRN, crn, false)
 
       // Then
       assertThat(allRiskScores.size).isEqualTo(3)
@@ -279,7 +280,7 @@ class RiskPredictorServiceTest {
       }.returns(null)
 
       // When
-      val allRiskScores = riskPredictorsService.getAllRiskScoresWithoutLaoCheck(IdentifierType.CRN, crn)
+      val allRiskScores = riskPredictorsService.getAllRiskScoresWithoutLaoCheck(IdentifierType.CRN, crn, false)
 
       // Should
       assertThat(allRiskScores.isEmpty())
@@ -475,7 +476,7 @@ class RiskPredictorServiceTest {
       }.returns(allRisksOasysRiskPredictorsDto)
 
       // When
-      val result = riskPredictorsService.getAllRiskScoresWithoutLaoCheck(IdentifierType.CRN, crn)
+      val result = riskPredictorsService.getAllRiskScoresWithoutLaoCheck(IdentifierType.CRN, crn, false)
 
       // Then
       assertThat(result[0].outputVersion).isEqualTo("1")
@@ -532,6 +533,54 @@ class RiskPredictorServiceTest {
 
       // Then
       assertThat(result.outputVersion).isEqualTo("1")
+    }
+
+    @Test
+    fun `getAllRiskScores - should include standalone assessments when requested`() {
+      // Given
+      val crn = "X12345"
+
+      val allRisksOasysRiskPredictorsDto = AllRisksOasysRiskPredictorsDto(
+        listOf(
+          provideOutput(LocalDateTime.of(2025, 1, 1, 12, 0, 0), null, true).copy(assessmentType = "STANDALONE"),
+        ),
+      )
+
+      every {
+        oasysApiClient.getRiskPredictorsForCompletedAssessments(crn)
+      }.returns(allRisksOasysRiskPredictorsDto)
+
+      // When
+      val result = riskPredictorsService.getAllRiskScores(IdentifierType.CRN, crn, includeStandaloneAssessments = true)
+
+      // Then
+      assertThat(result[0].assessmentType).isEqualTo(AssessmentType.STANDALONE)
+    }
+
+    @Test
+    fun `getAllRiskScoresWithoutLaoCheck - should include standalone assessments when requested`() {
+      // Given
+      val crn = "X12345"
+
+      val allRisksOasysRiskPredictorsDto = AllRisksOasysRiskPredictorsDto(
+        listOf(
+          provideOutput(LocalDateTime.of(2025, 1, 1, 12, 0, 0), null, true).copy(assessmentType = "STANDALONE"),
+        ),
+      )
+
+      every {
+        oasysApiClient.getRiskPredictorsForCompletedAssessments(crn)
+      }.returns(allRisksOasysRiskPredictorsDto)
+
+      // When
+      val result = riskPredictorsService.getAllRiskScoresWithoutLaoCheck(
+        IdentifierType.CRN,
+        crn,
+        includeStandaloneAssessments = true,
+      )
+
+      // Then
+      assertThat(result[0].assessmentType).isEqualTo(AssessmentType.STANDALONE)
     }
   }
 

--- a/wiremock-oasys-api/__files/ordsRiskPredictors.json
+++ b/wiremock-oasys-api/__files/ordsRiskPredictors.json
@@ -56,6 +56,13 @@
       "initiationDate": "2022-06-11T18:22:02",
       "status": "COMPLETE",
       "completedDate": "2022-06-11T18:23:20"
+    },
+    {
+      "assessmentPk": 123,
+      "assessmentType": "STANDALONE",
+      "initiationDate": "2026-07-27T15:36:59",
+      "status": "COMPLETE",
+      "completedDate": "2026-07-27T15:40:41"
     }
   ],
   "assessments": [
@@ -377,6 +384,90 @@
         "snsvDynamicYr2Band": "Medium",
         "snsvStaticCalculated": "Y",
         "snsvDynamicCalculated": "N"
+      }
+    },
+    {
+      "assessmentPk": 123,
+      "assessmentType": "STANDALONE",
+      "assessmentVersion": null,
+      "dateCompleted": "2026-07-27T15:40:41",
+      "assessorSignedDate": null,
+      "initiationDate": "2026-07-27T15:36:59",
+      "assessmentStatus": "COMPLETE",
+      "superStatus": "COMPLETE",
+      "laterWIPAssessmentExists": false,
+      "latestWIPDate": null,
+      "laterSignLockAssessmentExists": false,
+      "latestSignLockDate": null,
+      "laterPartCompUnsignedAssessmentExists": false,
+      "latestPartCompUnsignedDate": "2015-04-08T13:24:14",
+      "laterPartCompSignedAssessmentExists": false,
+      "latestPartCompSignedDate": "2018-02-20T15:32:29",
+      "laterCompleteAssessmentExists": false,
+      "latestCompleteDate": "2026-07-27T15:40:41",
+      "OGP": {
+        "ogpStWesc": null,
+        "ogpDyWesc": null,
+        "ogpTotWesc": null,
+        "ogp1Year": null,
+        "ogp2Year": null,
+        "ogpRisk": null
+      },
+      "OVP": {
+        "ovpStWesc": null,
+        "ovpDyWesc": null,
+        "ovpTotWesc": null,
+        "ovp1Year": null,
+        "ovp2Year": null,
+        "ovpRisk": null,
+        "ovpPrevWesc": null,
+        "ovpNonVioWesc": null,
+        "ovpAgeWesc": null,
+        "ovpVioWesc": null,
+        "ovpSexWesc": null
+      },
+      "OGRS": {
+        "ogrs31Year": 54,
+        "ogrs32Year": 71,
+        "ogrs3RiskRecon": null
+      },
+      "RSR": {
+        "rsrStaticOrDynamic": "STATIC",
+        "rsrExceptionError": null,
+        "rsrAlgorithmVersion": 6,
+        "rsrPercentageScore": 1.79,
+        "scoreLevel": "Medium"
+      },
+      "OSP": {
+        "ospImagePercentageScore": null,
+        "ospContactPercentageScore": null,
+        "ospImageScoreLevel": null,
+        "ospContactScoreLevel": null,
+        "ospIndirectImagesChildrenPercentageScore": 0,
+        "ospDirectContactPercentageScore": 0,
+        "ospIndirectImagesChildrenScoreLevel": "Not Applicable",
+        "ospDirectContactScoreLevel": "Not Applicable",
+        "ospDirectContactRiskReduction": null
+      },
+      "newActuarialPredictors": {
+        "ogrs4gYr2": 65.12,
+        "ogrs4gBand": "Medium",
+        "ogrs4gCalculated": "Y",
+        "ogrs4vYr2": 35.04,
+        "ogrs4vBand": "Medium",
+        "ogrs4vCalculated": "Y",
+        "ogp2Yr2": null,
+        "ogp2Band": null,
+        "ogp2Calculated": "E",
+        "ovp2Yr2": null,
+        "ovp2Band": null,
+        "ovp2Calculated": "E",
+        "snsvStaticYr2": 1.79,
+        "snsvStaticYr2Band": "Medium",
+        "snsvStaticCalculated": "Y",
+        "snsvDynamicYr2": null,
+        "snsvDynamicYr2Band": null,
+        "snsvDynamicCalculated": "E"
       }
     }
   ]


### PR DESCRIPTION
This adds an `includeStandaloneAssessments` request parameter to the [/risks/predictors/all/{identifierType}/{identifierValue}](https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/risk-predictors-controller/getAllRiskScoresVersioned_1) and [/risks/predictors/unsafe/all/{identifierType}/{identifierValue}](https://assess-risks-and-needs-dev.hmpps.service.justice.gov.uk/swagger-ui/index.html#/integration-controller/getAllRiskScoresVersioned) endpoints, allowing the tier service to request risk scores for Standalone CSRP assessments without affecting other clients.