### PR TITLE
Adding ROLE_COMMUNITY_SUPPORT_PROVIDER to /risks/crn/{crn} api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/RisksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/RisksController.kt
@@ -70,7 +70,7 @@ class RisksController(
       ApiResponse(responseCode = "200", description = "OK"),
     ],
   )
-  @PreAuthorize("hasAnyRole('ROLE_PROBATION', 'ROLE_CRS_PROVIDER', 'ROLE_OFFENDER_RISK_RO', 'ROLE_RISK_RESETTLEMENT_PASSPORT_RO', 'ROLE_RISK_INTEGRATIONS_RO')")
+  @PreAuthorize("hasAnyRole('ROLE_PROBATION', 'ROLE_CRS_PROVIDER', 'ROLE_OFFENDER_RISK_RO', 'ROLE_RISK_RESETTLEMENT_PASSPORT_RO', 'ROLE_RISK_INTEGRATIONS_RO' , 'ROLE_COMMUNITY_SUPPORT_PROVIDER')")
   @JsonView(View.AllRisksView::class)
   fun getRoshRisksByCrn(
     @Parameter(description = "CRN", required = true, example = "D1974X")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/RisksController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/assessrisksandneeds/api/controllers/RisksController.kt
@@ -70,7 +70,7 @@ class RisksController(
       ApiResponse(responseCode = "200", description = "OK"),
     ],
   )
-  @PreAuthorize("hasAnyRole('ROLE_PROBATION', 'ROLE_CRS_PROVIDER', 'ROLE_OFFENDER_RISK_RO', 'ROLE_RISK_RESETTLEMENT_PASSPORT_RO', 'ROLE_RISK_INTEGRATIONS_RO' , 'ROLE_COMMUNITY_SUPPORT_PROVIDER')")
+  @PreAuthorize("hasAnyRole('ROLE_PROBATION', 'ROLE_CRS_PROVIDER', 'ROLE_OFFENDER_RISK_RO', 'ROLE_RISK_RESETTLEMENT_PASSPORT_RO', 'ROLE_RISK_INTEGRATIONS_RO', 'ROLE_COMMUNITY_SUPPORT_PROVIDER')")
   @JsonView(View.AllRisksView::class)
   fun getRoshRisksByCrn(
     @Parameter(description = "CRN", required = true, example = "D1974X")


### PR DESCRIPTION
- Adding ROLE_COMMUNITY_SUPPORT_PROVIDER to /risks/crn/{crn} api. This will enable api's from the new community support product to access risk information by crn api